### PR TITLE
Discogs collection import, CSV sync, and UX overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Secrets
-sleevenotes.env
-
 # Python
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ A personal vinyl record collection manager. Single-page app backed by a FastAPI/
 - **Backend:** Python 3.12, FastAPI, SQLite, httpx
 - **Frontend:** Vanilla JS SPA (`static/index.html`) — no build step
 - **Container:** Docker Compose, port 2026, persistent `/data` volume
-- **Discogs API:** Token from `DISCOGS_TOKEN` env var
+- **Discogs API:** Token stored in the `settings` DB table (set via Settings modal)
 
 ## Project Structure
 
@@ -16,6 +16,7 @@ app.py              # FastAPI backend — all routes, DB, helpers
 static/index.html   # Entire frontend — HTML, CSS, JS in one file
 Dockerfile
 compose.yml
+compose.override.yml  # Forces local build (overrides registry image for dev)
 ```
 
 Runtime data (not in repo):
@@ -39,12 +40,14 @@ docker exec sleevenotes rm /data/sleevenotes.db
 
 ## Database
 
-Single table: `records`
+### `records` table
 
 | Column | Type | Notes |
 |---|---|---|
 | `id` | INTEGER PK | Auto-increment |
 | `discogs_id` | TEXT | Format: `r12345678` |
+| `instance_id` | TEXT | Discogs collection instance ID |
+| `folder_id` | INTEGER | Discogs collection folder |
 | `cat_no` | TEXT | Catalog number |
 | `artist` | TEXT | Comma-separated if multiple |
 | `title` | TEXT | |
@@ -52,50 +55,101 @@ Single table: `records`
 | `year` | INTEGER | Release year |
 | `format` | TEXT | e.g. "Vinyl, LP, Album" |
 | `cover_file` | TEXT | Cached image filename in `/data/images/` |
-| `is_new` | INTEGER | 0/1 boolean |
-| `orig_cond` | TEXT | S/M/NM/VG+/VG/G+/G/F/P |
-| `curr_cond` | TEXT | Same scale |
-| `status` | TEXT | "In Collection" / "Purchased" / "Returned" |
+| `is_new` | INTEGER | NULL = unknown, 0 = Pre-Owned, 1 = New |
+| `curr_cond` | TEXT | S/M/NM/VG+/VG/G+/G/F/P — media condition |
+| `sleeve_cond` | TEXT | Same scale — sleeve condition |
 | `retailer` | TEXT | |
 | `order_ref` | TEXT | |
 | `purchase_date` | TEXT | ISO 8601 (YYYY-MM-DD) |
-| `price` | REAL | Item cost (GBP) |
-| `pp` | REAL | Postage & packaging (GBP) |
+| `price` | REAL | Item cost (GBP); 0 means not entered |
+| `pp` | REAL | Postage & packaging (GBP); 0 means not entered |
 | `notes` | TEXT | |
-| `valuation` | REAL | Discogs lowest listing price |
+| `valuation` | REAL | Discogs lowest listing price; 0 means not fetched |
 | `created_at` | TEXT | Auto timestamp |
+| `deleted_at` | TEXT | Soft-delete timestamp; NULL = active |
 
-Schema migrations (e.g. adding `valuation`) are handled via guarded `ALTER TABLE` in `init_db()` — add new ones there.
+### `settings` table
+
+| Key | Default | Notes |
+|---|---|---|
+| `clean_artists` | `true` | Strip Discogs disambiguation numbers from display |
+| `include_pp` | `false` | Include P&P in Collection Cost KPI |
+| `hide_obvious_formats` | `true` | Global on/off for format tag hiding |
+| `hidden_format_tags` | `Album, LP, Stereo, Vinyl` | Comma-separated tags to hide from filter bar |
+| `discogs_username` | `` | Required for collection sync |
+| `discogs_token` | `` | Discogs API token (stored server-side, never sent to frontend) |
+| `discogs_field_mappings` | `{}` | JSON: `{field_id: db_col}` mapping custom Discogs fields → SN columns |
+
+`SETTINGS_DEFAULTS` in `app.py` is the single source of truth for defaults — used by both `init_db()` (INSERT OR IGNORE) and `POST /api/admin/factory-reset` (INSERT OR REPLACE).
+
+### `images` table
+Per-release image cache: `discogs_id`, `filename`, `seq`, `is_cover`.
+
+### `tracklist` table
+Per-release track data: `discogs_id`, `position`, `title`, `duration`, `type`, `seq`.
 
 ## API Endpoints
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/api/records` | List records (`?show_returned=false`) |
+| GET | `/api/records` | List records (excludes soft-deleted) |
 | POST | `/api/records` | Create record |
 | PUT | `/api/records/{id}` | Update record |
-| DELETE | `/api/records/{id}` | Delete record |
+| DELETE | `/api/records/{id}` | Soft-delete record |
 | GET | `/api/discogs/{release_id}` | Fetch metadata + valuation from Discogs |
 | POST | `/api/records/{id}/refresh` | Re-fetch Discogs data for existing record |
-| POST | `/api/import` | Upload pipe-delimited CSV |
-| GET | `/api/export` | Download pipe-delimited CSV |
-| POST | `/api/admin/format` | **DESTRUCTIVE** — delete all records |
+| GET | `/api/records/{id}/tracklist` | Get cached tracklist |
+| GET | `/api/records/{id}/images` | Get cached images |
+| POST | `/api/records/{id}/set-cover` | Set cover image |
+| GET | `/api/collection/fields` | Fetch Discogs custom field definitions |
+| GET | `/api/collection/preview` | Fetch full Discogs collection and return diff vs SN |
+| POST | `/api/collection/sync` | Apply a sync payload (to SN and/or Discogs) |
+| POST | `/api/import/csv` | Upload Discogs-format CSV → returns diff preview |
+| GET | `/api/export` | Download CSV (all DB fields) |
+| GET | `/api/settings` | Get all settings |
+| PUT | `/api/settings/{key}` | Update a setting |
+| POST | `/api/admin/format` | Delete all records (settings preserved) |
+| POST | `/api/admin/factory-reset` | Delete all records + restore all settings to defaults |
+| POST | `/api/admin/clear-images` | Delete all cached cover images from disk |
+
+### Discogs rate limiter
+All outbound Discogs API calls go through `discogs_get()` / `discogs_post()` wrappers that enforce a 55 req/min sliding-window limit (buffer under Discogs' 60/min). The limiter is process-wide — no manual sleep/batch logic anywhere else. On a 429 response, it waits 60 s and retries once. Image CDN calls (`i.discogs.com`) bypass the limiter — they are not API calls.
 
 ### Discogs fetch (`/api/discogs/{id}`)
 - Accepts `r12345678` or `12345678`
-- Fetches `/releases/{id}` — returns artist, title, label, cat_no, year, format, cover_file, valuation
-- `valuation` comes from `data["lowest_price"]` in the release response (not the marketplace API)
-- Downloads and caches cover image to `/data/images/{release_id}.{ext}`
+- Makes 2 concurrent Discogs calls: `/releases/{id}` + `/marketplace/stats/{id}`
+- Returns artist, title, label, cat_no, year, format, cover_file, valuation
+- Downloads and caches all images (up to 8) to `/data/images/`; populates `tracklist` table
 
 ### Record refresh (`/api/records/{id}/refresh`)
-- Updates Discogs-sourced fields only: artist, title, label, cat_no, year, format, cover_file, valuation
-- Preserves all user-entered fields (price, pp, date, retailer, notes, status, condition, etc.)
+- Updates Discogs-sourced fields only: artist, title, label, cat_no, year, format, cover_file, valuation, tracklist, images
+- Preserves all user-entered fields
 
-### Import CSV
-- Pipe-delimited (`|`), first row is header
-- Column aliases: `discogsId`→`discogs_id`, `catNo`→`cat_no`, `origCond`→`orig_cond`, `currCond`→`curr_cond`, `orderRef`→`order_ref`
-- Date normalisation: accepts DD/MM/YYYY, D/M/YYYY, YYYY-MM-DD
-- Deduplication: skips rows where source `id` or `discogs_id` already exists in DB (checked both within-file and against DB)
+### Collection sync (`/api/collection/sync`)
+- Accepts `{to_sleevenotes: [...], to_discogs: [...]}` payload
+- New SN records trigger a background `_refresh_new_records` task (images + tracklist + valuation)
+- Returns `sn_refreshing: N` when background fetch is in flight; frontend polls until covers appear
+
+### Import CSV (`/api/import/csv`)
+- Accepts a Discogs-format CSV (from Discogs export or SN export)
+- Standard Discogs columns: `Catalog#`, `Artist`, `Title`, `Label`, `Format`, `Released`, `release_id`, `CollectionFolder`, `Collection Media Condition`, `Collection Sleeve Condition`
+- Custom fields: `Collection [Field Name]` columns → resolved via `discogs_field_mappings`
+- SN export fallback: tries `SN_{col}` then bare `{col}` for SN-specific columns
+- **`db_only` is always empty** — CSV import is partial; records absent from the CSV are untouched
+- Returns a diff object (same shape as `/api/collection/preview`) — apply via `/api/collection/sync`
+
+### Export CSV (`/api/export`)
+- Standard Discogs column names for Discogs-sourced fields
+- `Collection [Field Name]` for mapped custom fields
+- `SN_{col}` prefix for unmapped SN fields (`SN_retailer`, `SN_price`, etc.) and SN extras (`SN_id`, `SN_instance_id`, `SN_is_new`, `SN_cover_file`)
+- Ordering: `instance_id` ASC, then `id` ASC
+
+### Diff computation (`compute_diff`)
+- Compares prospective items (from Discogs or CSV) against the SN DB
+- Matches by `instance_id` first, falls back to `discogs_id`
+- Compares `DISCOGS_SOURCED` fields + any mapped custom fields
+- Uses `None`-safe string comparison: `None` → `""`, not `str(None or "")`
+- For `price`, `pp`, `valuation`: treats `None` (blank from source) as equivalent to `0` (DB default for "not entered") — avoids false positives when fields aren't mapped
 
 ## Frontend Architecture (`static/index.html`)
 
@@ -103,50 +157,80 @@ Everything lives in one file. No framework, no build step.
 
 ### Global state
 ```js
-records      // array — full dataset from API
-currentView  // 'table' | 'tile'
-editingId    // null or record id
-fetchedMeta  // Discogs preview data during add/edit
-sortCol      // active sort column key or null
-sortDir      // 'asc' | 'desc' | null
+records           // array — full dataset from API
+currentView       // 'table' | 'tile'
+editingId         // null or record id
+fetchedMeta       // Discogs preview data during add/edit
+sortCol           // active sort column key or null
+sortDir           // 'asc' | 'desc' | null
+showValuations    // bool — toggle collection value display
+showTags          // bool — toggle format filter bar visibility
+filterFormat      // active format tag string, or null
+diffData          // last sync diff payload
+syncSource        // 'discogs' | 'csv' — controls sync modal behaviour
+hideObviousFormats // bool — global on/off for format tag hiding
+hiddenFormatTags  // Set<string> — tags to hide from filter bar
 ```
+
+### localStorage persistence
+All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view`, `showValuations`, `showTags`, `groupByArtist`, `toolbarExpanded`.
 
 ### Key functions
 
 | Function | Purpose |
 |---|---|
 | `loadRecords()` | Fetch `/api/records`, update state, render, stats, retailer list |
-| `getFiltered()` | Filter by search + status — no sorting (pure filter) |
+| `getFiltered()` | Filter by search — no sorting (pure filter) |
 | `applySortCol(rows)` | Sort array by `sortCol`/`sortDir` |
 | `headerSort(col)` | Cycle sort: asc → desc → clear |
 | `renderTable()` | Build sortable table with optional artist grouping |
 | `renderTiles()` | Build cover art grid (always sorted artist → year) |
-| `th(col, label, cls)` | Generate sortable `<th>` with arrow indicator |
 | `rowHtml(r)` | Generate single table row HTML |
 | `openAdd()` / `openEdit(id)` | Open add/edit form modal |
 | `fetchDiscogs()` | Fetch `/api/discogs/{id}`, populate form fields |
-| `doFetchRange(start, end)` | Bulk refresh batch with 2s delay between records |
+| `startCoverPoll(n)` | Poll `loadRecords()` every 8s until n new covers appear (max 40 polls) |
+| `updateStats()` | Update KPI bar: Total Records, Collection Cost, Collection Value |
+| `formatTags(s, respectHide)` | Parse format string into tag array; filters `hiddenFormatTags` when enabled |
+| `condLabel(c)` | Expand condition code to label; returns `'Unknown'` for blank |
 | `fmtDate(s)` | YYYY-MM-DD → DD/MM/YYYY for display |
 | `toISODate(s)` | DD/MM/YYYY → YYYY-MM-DD for date input |
+| `lsGet(key, fallback)` / `lsSet(key, val)` | localStorage helpers (prefix `sn_`) |
+| `restoreLocalState()` | Rehydrate all UI state from localStorage on load |
+| `renderSyncPreview(diff)` | Render sync/import diff modal; respects `syncSource` |
+| `importCsv(input)` | POST CSV → sets `syncSource='csv'` → opens sync modal |
+| `openSettings()` | Open settings modal; reloads field mapping in-place |
+| `saveSettings()` | Persist settings; stays open; refreshes field mapping if username changed |
 
 ### Views
-- **Table:** Clickable column headers cycle asc/desc/clear. "Group by artist" toggle (hidden in tile view) overrides column sort with artist A-Z + year.
+- **Table:** Clickable column headers cycle asc/desc/clear. "Group by artist" toggle overrides column sort with artist A-Z + year.
 - **Tiles:** Always sorted artist A-Z → year. Clicking a tile opens detail modal.
 
+### Toolbar
+Collapsible via the "Options ▾" button in the header. Collapsed by default on mobile (`< 768px`), expanded on desktop. State persisted to localStorage.
+
 ### Modals
-- `modal-detail` — read-only record detail (opened from tile click)
+- `modal-detail` — read-only record detail (tile click)
 - `modal-form` — add/edit form with Discogs lookup
-- `modal-import` — CSV upload
-- `modal-settings` — batch Discogs refresh + Format DB (danger zone with safety toggle)
+- `modal-discogs-sync` — diff preview; shared between Discogs collection sync and CSV import. `syncSource` controls labels and available actions (CSV hides "Discogs →" direction)
+- `modal-settings` — Display settings, Discogs config + field mapping, Data (import/export), Danger Zone. **Save stays open** (reload fields in-place); Close button dismisses.
+
+### Settings modal sections (top to bottom)
+1. **Display** — Clean artists, Include P&P, Hide format tags (toggle + tag list)
+2. **Discogs** — Username, Token, Refresh Metadata, Field Mapping, Sync Collection
+3. **Data** — Import from CSV, Export to CSV
+4. **Danger Zone** — Delete All Records (records only), Format Database (factory reset), Clear Image Cache
 
 ## Discogs Grading Scale
 S (Sealed) → M → NM → VG+ → VG → G+ → G → F → P
 
 ## Important Behaviours
 
-- **Date storage:** Always YYYY-MM-DD in DB. `normalise_date()` (backend) and `toISODate()` (frontend) handle legacy DD/MM/YYYY on the way in. `fmtDate()` converts to DD/MM/YYYY for display only.
-- **Cover images:** Cached on first fetch; subsequent fetches with the same release ID are skipped unless the file is missing. On refresh, falls back to existing `cover_file` if download fails.
-- **Valuation:** Sourced from `lowest_price` field in the Discogs `/releases/{id}` response — no separate marketplace API call needed.
-- **Rate limiting:** Discogs allows 60 req/min. Bulk refresh fires 5 records concurrently per batch with a 5-second pause between batches (5 req per 5s = 60/min). Each refresh is 1 Discogs API call.
-- **SPA routing:** `GET /{full_path:path}` serves matching static files or falls back to `index.html`. API routes are defined before this catch-all and always take priority.
-- **Empty DB:** `list_records` catches `OperationalError` (table missing after DB deletion while server is live), calls `init_db()`, and returns `[]` rather than 500.
+- **Date storage:** Always YYYY-MM-DD in DB. `normalise_date()` (backend) and `toISODate()` (frontend) handle DD/MM/YYYY on the way in. `fmtDate()` converts to DD/MM/YYYY for display only.
+- **Cover images:** Cached on first fetch; re-download skipped if file already exists. Multiple images per release stored in `images` table (up to 8). User can set cover via detail modal.
+- **Valuation:** Per-record, sourced from `/marketplace/stats/{id}` on fetch/refresh. Summed for the Collection Value KPI.
+- **is_new:** Three-state — `NULL` (unknown/not set, no badge shown), `0` (Pre-Owned), `1` (New). Records imported without a mapped `is_new` field get NULL.
+- **Rate limiting:** Single process-wide broker (`_discogs_acquire()`) enforces 55 req/min. All Discogs calls use `discogs_get()` / `discogs_post()`. No manual sleep/batch logic.
+- **Background refresh:** After collection sync creates new records, `_refresh_new_records` runs as a FastAPI background task. Frontend calls `startCoverPoll(n)` to reload until covers appear.
+- **SPA routing:** `GET /{full_path:path}` serves static files or falls back to `index.html`. API routes are defined before this catch-all.
+- **Empty DB:** `list_records` catches `OperationalError`, calls `init_db()`, returns `[]` rather than 500.
+- **No schema migrations:** `init_db()` uses `CREATE TABLE IF NOT EXISTS` only. Assume fresh installs. To reset: delete `/data/sleevenotes.db`.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A personal vinyl record collection manager. Built for my own use out of curiosit
 - Pulls current valuations (lowest marketplace listing) from Discogs
 - Table and tile views, with filtering by format tags and status
 - Detail cards with image carousels and tracklists
-- Bulk refresh of Discogs data
-- Import/export via pipe-delimited CSV
+- Bulk import/sync from your Discogs collection or a CSV file
+- Import/export via CSV
 
 ## Stack
 
@@ -24,19 +24,14 @@ A personal vinyl record collection manager. Built for my own use out of curiosit
 
 ## Running it
 
-You'll need a [Discogs API token](https://www.discogs.com/settings/developers).
-
-1. Copy `sleevenotes.env.example` to `sleevenotes.env` and add your token:
-   ```
-   DISCOGS_TOKEN=your_token_here
-   ```
-
-2. Run:
+1. Run:
    ```bash
    docker compose up -d
    ```
 
-3. Open [http://localhost:2026](http://localhost:2026)
+2. Open [http://localhost:2026](http://localhost:2026)
+
+3. Go to **Settings → Discogs** and enter your [Discogs API token](https://www.discogs.com/settings/developers) and username.
 
 Data is persisted in a Docker volume (`sleevenotes_data`).
 

--- a/app.py
+++ b/app.py
@@ -1,27 +1,87 @@
-import os
 import io
 import csv
+import json
+import re
 import sqlite3
 import asyncio
+import logging
 import httpx
 from pathlib import Path
 from datetime import datetime
-from fastapi import FastAPI, HTTPException, UploadFile, File
+from fastapi import BackgroundTasks, FastAPI, HTTPException, UploadFile, File
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import Optional
 
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("sleevenotes")
+
 DATA_DIR = Path("/data")
 DB_PATH = DATA_DIR / "sleevenotes.db"
 IMAGES_DIR = DATA_DIR / "images"
-DISCOGS_TOKEN = os.environ.get("DISCOGS_TOKEN", "")
-DISCOGS_HEADERS = {
-    "Authorization": f"Discogs token={DISCOGS_TOKEN}",
-    "User-Agent": "SleeveNotes/1.0",
-}
+
+# ── Discogs rate limiter ──────────────────────────────────────────────────────
+# Single process-wide broker: all Discogs API calls acquire a slot here.
+# Cap at 55/min (buffer under the 60/min Discogs limit).
+
+_discogs_lock = asyncio.Lock()
+_discogs_call_times: list[float] = []
+_DISCOGS_MAX_PER_MIN = 55
+
+
+async def _discogs_acquire() -> None:
+    """Block until a Discogs API slot is available."""
+    global _discogs_call_times
+    async with _discogs_lock:
+        loop = asyncio.get_running_loop()
+        now = loop.time()
+        cutoff = now - 60.0
+        _discogs_call_times = [t for t in _discogs_call_times if t > cutoff]
+        if len(_discogs_call_times) >= _DISCOGS_MAX_PER_MIN:
+            wait = (_discogs_call_times[0] - cutoff) + 0.05
+            log.debug("Discogs rate limit: waiting %.2fs", wait)
+            await asyncio.sleep(wait)
+            now = loop.time()
+            cutoff = now - 60.0
+            _discogs_call_times = [t for t in _discogs_call_times if t > cutoff]
+        _discogs_call_times.append(loop.time())
+
+
+async def discogs_get(client: httpx.AsyncClient, url: str, **kwargs) -> httpx.Response:
+    await _discogs_acquire()
+    resp = await client.get(url, **kwargs)
+    if resp.status_code == 429:
+        log.warning("Discogs 429 on GET %s — waiting 60s then retrying", url)
+        await asyncio.sleep(60)
+        await _discogs_acquire()
+        resp = await client.get(url, **kwargs)
+    return resp
+
+
+async def discogs_post(client: httpx.AsyncClient, url: str, **kwargs) -> httpx.Response:
+    await _discogs_acquire()
+    resp = await client.post(url, **kwargs)
+    if resp.status_code == 429:
+        log.warning("Discogs 429 on POST %s — waiting 60s then retrying", url)
+        await asyncio.sleep(60)
+        await _discogs_acquire()
+        resp = await client.post(url, **kwargs)
+    return resp
+
 
 app = FastAPI(title="SleeveNotes")
+
+def get_discogs_headers() -> dict:
+    token = ""
+    try:
+        with get_db() as conn:
+            row = conn.execute("SELECT value FROM settings WHERE key='discogs_token'").fetchone()
+            if row and row["value"].strip():
+                token = row["value"].strip()
+    except Exception:
+        pass
+    return {"Authorization": f"Discogs token={token}", "User-Agent": "SleeveNotes/1.0"}
 
 # ── DB ────────────────────────────────────────────────────────────────────────
 
@@ -29,6 +89,17 @@ def get_db():
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     return conn
+
+SETTINGS_DEFAULTS: dict[str, str] = {
+    "clean_artists":        "true",
+    "include_pp":           "false",
+    "hide_obvious_formats": "true",
+    "hidden_format_tags":   "Album, LP, Stereo, Vinyl",
+    "discogs_username":     "",
+    "discogs_token":        "",
+    "discogs_field_mappings": "{}",
+}
+
 
 def init_db():
     IMAGES_DIR.mkdir(parents=True, exist_ok=True)
@@ -44,10 +115,9 @@ def init_db():
             year        INTEGER,
             format      TEXT,
             cover_file  TEXT,
-            is_new      INTEGER NOT NULL DEFAULT 0,
-            orig_cond   TEXT,
+            is_new      INTEGER,
             curr_cond   TEXT,
-            status      TEXT NOT NULL DEFAULT 'In Collection',
+            sleeve_cond TEXT,
             retailer    TEXT,
             order_ref   TEXT,
             purchase_date TEXT,
@@ -80,14 +150,8 @@ def init_db():
         );
         """)
         # Seed default settings (INSERT OR IGNORE preserves user changes)
-        conn.execute("INSERT OR IGNORE INTO settings (key, value) VALUES ('clean_artists', 'true')")
-        conn.execute("INSERT OR IGNORE INTO settings (key, value) VALUES ('include_pp', 'false')")
-        conn.execute("INSERT OR IGNORE INTO settings (key, value) VALUES ('hide_obvious_formats', 'true')")
-        # Migrations
-        try:
-            conn.execute("ALTER TABLE records ADD COLUMN deleted_at TEXT")
-        except sqlite3.OperationalError:
-            pass
+        for key, value in SETTINGS_DEFAULTS.items():
+            conn.execute("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", (key, value))
 
 init_db()
 
@@ -102,10 +166,9 @@ class RecordIn(BaseModel):
     year: Optional[int] = None
     format: Optional[str] = ""
     cover_file: Optional[str] = ""
-    is_new: bool = False
-    orig_cond: Optional[str] = ""
+    is_new: Optional[bool] = None
     curr_cond: Optional[str] = ""
-    status: str = "In Collection"
+    sleeve_cond: Optional[str] = ""
     retailer: Optional[str] = ""
     order_ref: Optional[str] = ""
     purchase_date: Optional[str] = ""
@@ -139,7 +202,7 @@ def normalise_date(s: str) -> str:
 
 def row_to_dict(row):
     d = dict(row)
-    d["is_new"] = bool(d["is_new"])
+    d["is_new"] = None if d["is_new"] is None else bool(d["is_new"])
     return d
 
 def find_cached_image(release_id: str) -> str:
@@ -152,7 +215,7 @@ def find_cached_image(release_id: str) -> str:
             return matches[0].name
     return ""
 
-async def download_all_images(images_data: list, release_id: str) -> list[dict]:
+async def download_all_images(images_data: list, release_id: str, headers: dict) -> list[dict]:
     """Download all images for a release (capped at 8). Returns list of {filename, seq}."""
     results = []
     async with httpx.AsyncClient(timeout=15) as client:
@@ -165,7 +228,7 @@ async def download_all_images(images_data: list, release_id: str) -> list[dict]:
             dest = IMAGES_DIR / filename
             if not dest.exists():
                 try:
-                    r = await client.get(url, headers=DISCOGS_HEADERS)
+                    r = await client.get(url, headers=headers)
                     if r.status_code == 200:
                         dest.write_bytes(r.content)
                 except Exception:
@@ -214,20 +277,481 @@ def upsert_tracklist(discogs_id: str, tracks: list):
                  t.get("duration", ""), t.get("type_", "track"), seq)
             )
 
+# ── Collection import helpers ─────────────────────────────────────────────────
+
+DISCOGS_SOURCED = {"artist", "title", "label", "cat_no", "year", "format"}
+
+DISCOGS_CONDITION_MAP = {
+    "Mint (M)":               "M",
+    "Near Mint (NM or M-)":   "NM",
+    "Very Good Plus (VG+)":   "VG+",
+    "Very Good (VG)":         "VG",
+    "Good Plus (G+)":         "G+",
+    "Good (G)":               "G",
+    "Fair (F)":               "F",
+    "Poor (P)":               "P",
+}
+
+def normalise_condition(val: str) -> str:
+    return DISCOGS_CONDITION_MAP.get(val.strip(), val.strip())
+MAPPED_WRITEABLE = {"purchase_date", "price", "pp", "retailer", "order_ref",
+                    "curr_cond", "sleeve_cond", "notes"}
+
+def parse_collection_item(item: dict, field_mappings: dict) -> dict:
+    info = item.get("basic_information", {})
+    rid = f"r{info['id']}"
+    labels = info.get("labels", [])
+    formats = info.get("formats", [])
+    fmt_parts = [formats[0].get("name", "")] if formats else []
+    if formats and formats[0].get("descriptions"):
+        fmt_parts.extend(formats[0]["descriptions"])
+    fmt = ", ".join(sorted(p for p in fmt_parts if p))
+    record: dict = {
+        "discogs_id": rid,
+        "instance_id": str(item["instance_id"]),
+        "folder_id": item.get("folder_id", 1),
+        "artist": ", ".join(a["name"] for a in info.get("artists", [])),
+        "title": info.get("title", ""),
+        "label": labels[0].get("name", "") if labels else "",
+        "cat_no": labels[0].get("catno", "") if labels else "",
+        "year": info.get("year"),
+        "format": fmt.strip(),
+    }
+    notes_map = {str(n["field_id"]): n["value"] for n in item.get("notes", [])}
+    for field_id, db_col in field_mappings.items():
+        if not db_col:
+            continue
+        raw = notes_map.get(field_id)
+        if raw is None or str(raw).strip() == "":
+            record[db_col] = None  # explicit None so "Discogs →" can clear SN values
+            continue
+        val: object = raw
+        if db_col == "purchase_date":
+            val = normalise_date(str(val))
+        elif db_col in ("price", "pp", "valuation"):
+            try:
+                cleaned = re.sub(r"[^\d.]", "", str(val))
+                val = float(cleaned) if cleaned else None
+            except (ValueError, TypeError):
+                val = None
+        elif db_col in ("curr_cond", "sleeve_cond"):
+            val = normalise_condition(str(val))
+        record[db_col] = val
+    return record
+
+
+def compute_diff(parsed_items: list[dict]) -> dict:
+    """Compare a list of pre-parsed flat record dicts against the SN database."""
+    with get_db() as conn:
+        fm_row = conn.execute("SELECT value FROM settings WHERE key='discogs_field_mappings'").fetchone()
+        db_rows = conn.execute("SELECT * FROM records WHERE deleted_at IS NULL").fetchall()
+    try:
+        field_mappings = json.loads(fm_row["value"] if fm_row else "{}")
+    except json.JSONDecodeError:
+        field_mappings = {}
+    db_records = [row_to_dict(r) for r in db_rows]
+    db_by_instance = {r["instance_id"]: r for r in db_records if r.get("instance_id")}
+    db_by_discogs  = {r["discogs_id"]: r for r in db_records if r.get("discogs_id")}
+    matched_ids: set = set()
+    mapped_cols = {v for v in field_mappings.values() if v}
+    compare_cols = DISCOGS_SOURCED | mapped_cols
+    result: dict = {"new": [], "changed": [], "unchanged": [], "db_only": []}
+    for prospective in parsed_items:
+        db_rec = db_by_instance.get(prospective.get("instance_id"))
+        if not db_rec and prospective.get("discogs_id") and db_by_discogs.get(prospective["discogs_id"]):
+            db_rec = db_by_discogs[prospective["discogs_id"]]
+            log.info("Matched %s via discogs_id fallback (stored instance_id=%r, live=%r)",
+                     prospective["discogs_id"], db_rec.get("instance_id"), prospective.get("instance_id"))
+        if not db_rec:
+            result["new"].append(prospective)
+        else:
+            matched_ids.add(db_rec["id"])
+            changes = {}
+            for col in compare_cols:
+                new_val = prospective.get(col)
+                old_val = db_rec.get(col)
+                # For numeric fields with a 0 default, treat None (blank from source) and
+                # 0/0.0 (DB default meaning "not entered") as equivalent — avoids false positives.
+                if col in ("price", "pp", "valuation"):
+                    if new_val is None and (old_val is None or old_val == 0):
+                        continue
+                new_str = "" if new_val is None else str(new_val).strip()
+                old_str = "" if old_val is None else str(old_val).strip()
+                if not new_str and not old_str:
+                    continue
+                if new_str != old_str:
+                    changes[col] = {"from": old_val, "to": new_val}
+            if changes:
+                result["changed"].append({
+                    "record_id": db_rec["id"],
+                    "current": db_rec,
+                    "prospective": prospective,
+                    "changes": changes,
+                })
+            else:
+                result["unchanged"].append({
+                    "record_id": db_rec["id"],
+                    "artist": db_rec.get("artist", ""),
+                    "title": db_rec.get("title", ""),
+                })
+    for rec in db_records:
+        if rec["id"] not in matched_ids:
+            result["db_only"].append(rec)
+    return result
+
+
+def parse_discogs_csv_row(row: dict, name_to_db_col: dict) -> dict | None:
+    """Parse one row of a Discogs-format CSV (or SN export) into a flat record dict."""
+    release_id = (row.get("release_id") or "").strip()
+    if not release_id:
+        return None
+    record: dict = {
+        "discogs_id": f"r{release_id}",
+        "instance_id": (row.get("SN_instance_id") or row.get("instance_id") or "").strip() or None,
+        "artist": (row.get("Artist") or "").strip(),
+        "title": (row.get("Title") or "").strip(),
+        "label": (row.get("Label") or "").strip(),
+        "cat_no": (row.get("Catalog#") or "").strip(),
+        "format": (row.get("Format") or "").strip(),
+    }
+    try:
+        record["year"] = int(row.get("Released") or 0) or None
+    except (ValueError, TypeError):
+        record["year"] = None
+    try:
+        record["folder_id"] = int(row.get("CollectionFolder") or row.get("folder_id") or 1)
+    except (ValueError, TypeError):
+        record["folder_id"] = 1
+
+    # Standard condition columns
+    for csv_col, db_col in (("Collection Media Condition", "curr_cond"),
+                             ("Collection Sleeve Condition", "sleeve_cond")):
+        val = (row.get(csv_col) or "").strip()
+        record[db_col] = normalise_condition(val) if val else None
+
+    # Raw DB column names (SN export fallback; try SN_ prefix first, then bare name)
+    for db_col in ("retailer", "order_ref", "purchase_date", "price", "pp", "notes", "valuation",
+                   "is_new", "cover_file", "curr_cond", "sleeve_cond"):
+        if db_col in record:
+            continue
+        val = (row.get(f"SN_{db_col}") or row.get(db_col) or "").strip()
+        if not val:
+            continue
+        if db_col == "purchase_date":
+            record[db_col] = normalise_date(val)
+        elif db_col in ("price", "pp", "valuation"):
+            try:
+                cleaned = re.sub(r"[^\d.]", "", val)
+                record[db_col] = float(cleaned) if cleaned else None
+            except (ValueError, TypeError):
+                record[db_col] = None
+        elif db_col in ("curr_cond", "sleeve_cond"):
+            record[db_col] = normalise_condition(val) or None
+        elif db_col == "is_new":
+            record[db_col] = 1 if val.lower() in ("1", "true", "yes") else 0
+        else:
+            record[db_col] = val
+
+    # Custom Collection [Field Name] columns (highest priority — override raw DB cols)
+    for field_name, db_col in name_to_db_col.items():
+        if not db_col:
+            continue
+        val = (row.get(f"Collection {field_name}") or "").strip()
+        if not val:
+            continue
+        if db_col == "purchase_date":
+            record[db_col] = normalise_date(val)
+        elif db_col in ("price", "pp", "valuation"):
+            try:
+                cleaned = re.sub(r"[^\d.]", "", val)
+                record[db_col] = float(cleaned) if cleaned else None
+            except (ValueError, TypeError):
+                record[db_col] = None
+        elif db_col in ("curr_cond", "sleeve_cond"):
+            record[db_col] = normalise_condition(val) or None
+        else:
+            record[db_col] = val
+
+    return record
+
+
+# ── Routes: Discogs collection import ────────────────────────────────────────
+
+@app.get("/api/collection/fields")
+async def collection_fields():
+    with get_db() as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key='discogs_username'").fetchone()
+    username = (row["value"] if row else "").strip()
+    if not username:
+        raise HTTPException(status_code=400, detail="Discogs username not configured")
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await discogs_get(
+            client,
+            f"https://api.discogs.com/users/{username}/collection/fields",
+            headers=get_discogs_headers(),
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail="Discogs API error")
+    return resp.json()
+
+
+@app.get("/api/collection/preview")
+async def collection_preview(record_id: int = None):
+    with get_db() as conn:
+        rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    settings = {r["key"]: r["value"] for r in rows}
+    username = settings.get("discogs_username", "").strip()
+    if not username:
+        raise HTTPException(status_code=400, detail="Discogs username not configured")
+    try:
+        field_mappings: dict = json.loads(settings.get("discogs_field_mappings", "{}"))
+    except json.JSONDecodeError:
+        field_mappings = {}
+
+    hdrs = get_discogs_headers()
+    async with httpx.AsyncClient(timeout=20) as client:
+        first = await discogs_get(
+            client,
+            f"https://api.discogs.com/users/{username}/collection/folders/0/releases",
+            params={"per_page": 100, "page": 1},
+            headers=hdrs,
+        )
+        if first.status_code != 200:
+            raise HTTPException(status_code=first.status_code, detail="Discogs API error")
+        data = first.json()
+        pages = data["pagination"]["pages"]
+        items = data["releases"]
+        if pages > 1:
+            responses = await asyncio.gather(*[
+                discogs_get(
+                    client,
+                    f"https://api.discogs.com/users/{username}/collection/folders/0/releases",
+                    params={"per_page": 100, "page": p},
+                    headers=hdrs,
+                )
+                for p in range(2, min(pages + 1, 11))
+            ])
+            for resp in responses:
+                if resp.status_code == 200:
+                    items.extend(resp.json()["releases"])
+
+    items.sort(key=lambda x: x.get("instance_id", 0))
+    parsed = [parse_collection_item(item, field_mappings) for item in items]
+    diff = compute_diff(parsed)
+    if record_id is not None:
+        diff["new"] = []
+        diff["changed"]   = [r for r in diff["changed"]   if r["record_id"] == record_id]
+        diff["unchanged"] = [r for r in diff["unchanged"] if r["record_id"] == record_id]
+        diff["db_only"]   = [r for r in diff["db_only"]   if r["id"]        == record_id]
+    return diff
+
+
+# ── Routes: Discogs sync ──────────────────────────────────────────────────────
+
+class SyncFieldUpdate(BaseModel):
+    field_id: str
+    value: str
+
+class SyncToSleeveNotes(BaseModel):
+    action: str  # "create" or "update"
+    record_id: Optional[int] = None
+    prospective: dict
+
+class SyncToDiscogs(BaseModel):
+    action: str  # "create" or "update"
+    record_id: Optional[int] = None
+    instance_id: Optional[str] = None
+    discogs_id: str
+    folder_id: int = 1
+    updates: list[SyncFieldUpdate]
+
+class SyncPayload(BaseModel):
+    to_sleevenotes: list[SyncToSleeveNotes]
+    to_discogs: list[SyncToDiscogs]
+
+def _insert_record(conn, rec: dict) -> int:
+    _raw = rec.get("is_new")
+    is_new = None if _raw is None else (1 if str(_raw) in ("1", "True", "true") else 0)
+    cur = conn.execute("""
+        INSERT INTO records
+          (discogs_id, instance_id, folder_id, cat_no, artist, title, label, year, format,
+           cover_file, is_new, curr_cond, sleeve_cond, retailer, order_ref,
+           purchase_date, price, pp, notes, valuation)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, (
+        rec.get("discogs_id", ""), rec.get("instance_id", ""),
+        int(rec.get("folder_id") or 1),
+        rec.get("cat_no", ""), rec.get("artist", ""), rec.get("title", ""),
+        rec.get("label", ""), rec.get("year"), rec.get("format", ""),
+        rec.get("cover_file") or find_cached_image(rec.get("discogs_id", "")),
+        is_new, rec.get("curr_cond") or None, rec.get("sleeve_cond") or None,
+        rec.get("retailer", ""),
+        rec.get("order_ref", ""),
+        normalise_date(str(rec.get("purchase_date", "") or "")),
+        float(rec.get("price", 0) or 0), float(rec.get("pp", 0) or 0),
+        rec.get("notes", ""), 0.0,
+    ))
+    return cur.lastrowid
+
+async def _refresh_from_discogs(client, hdrs: dict, record_id: int, discogs_id: str):
+    """Fetch images and valuation from Discogs for a record. Silently ignores failures."""
+    try:
+        rid = discogs_id.lstrip("r")
+        release_resp, stats_resp = await asyncio.gather(
+            discogs_get(client, f"https://api.discogs.com/releases/{rid}", headers=hdrs),
+            discogs_get(client, f"https://api.discogs.com/marketplace/stats/{rid}", headers=hdrs),
+        )
+        if release_resp.status_code != 200:
+            return
+        data = release_resp.json()
+        downloaded = await download_all_images(data.get("images", []), f"r{rid}", hdrs)
+        cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=False)
+        upsert_tracklist(f"r{rid}", data.get("tracklist", []))
+        stats = stats_resp.json() if stats_resp.status_code == 200 else {}
+        lp = stats.get("lowest_price") or {}
+        valuation = float(lp.get("value") or 0)
+        with get_db() as conn:
+            conn.execute(
+                "UPDATE records SET cover_file=?, valuation=? WHERE id=?",
+                (cover_file or "", valuation, record_id),
+            )
+    except Exception:
+        pass
+
+async def _push_field_updates(client, username: str, hdrs: dict,
+                               rid: str, instance_id: str, folder_id: int,
+                               updates: list[SyncFieldUpdate]) -> list[dict]:
+    errors = []
+    for upd in updates:
+        url = (f"https://api.discogs.com/users/{username}/collection"
+               f"/folders/{folder_id}/releases/{rid}"
+               f"/instances/{instance_id}/fields/{upd.field_id}")
+        try:
+            log.info("Discogs POST %s  value=%r", url, upd.value)
+            resp = await discogs_post(client, url, json={"value": upd.value}, headers=hdrs)
+            log.info("Discogs response %s  body=%s", resp.status_code, resp.text[:300])
+            if resp.status_code == 422:
+                log.warning("Field %s rejected (dropdown value not in options?): %s", upd.field_id, resp.text[:200])
+            elif resp.status_code not in (200, 201, 204):
+                errors.append({"error": f"HTTP {resp.status_code}: {resp.text[:200]}"})
+        except Exception as e:
+            log.exception("Discogs field update failed")
+            errors.append({"error": str(e)})
+    return errors
+
+async def _refresh_new_records(new_records: list[tuple[int, str]], hdrs: dict):
+    async with httpx.AsyncClient(timeout=30) as client:
+        await asyncio.gather(*[
+            _refresh_from_discogs(client, hdrs, rec_id, did)
+            for rec_id, did in new_records
+        ])
+
+@app.post("/api/collection/sync")
+async def collection_sync(payload: SyncPayload, background_tasks: BackgroundTasks):
+    with get_db() as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key='discogs_username'").fetchone()
+    username = (row["value"] if row else "").strip()
+    if not username:
+        raise HTTPException(status_code=400, detail="Discogs username not configured")
+
+    hdrs = get_discogs_headers()
+    stats = {"sn_created": 0, "sn_updated": 0,
+             "discogs_created": 0, "discogs_updated": 0,
+             "failed": 0, "errors": []}
+
+    # SleeveNotes DB writes
+    new_records: list[tuple[int, str]] = []  # (record_id, discogs_id) for post-insert refresh
+    with get_db() as conn:
+        for item in payload.to_sleevenotes:
+            try:
+                if item.action == "create":
+                    row_id = _insert_record(conn, item.prospective)
+                    new_records.append((row_id, item.prospective.get("discogs_id", "")))
+                    stats["sn_created"] += 1
+                else:
+                    p = item.prospective
+                    update_fields = {k: v for k, v in p.items()
+                                     if k in DISCOGS_SOURCED | MAPPED_WRITEABLE | {"instance_id", "folder_id"}}
+                    if update_fields:
+                        clause = ", ".join(f"{k}=?" for k in update_fields)
+                        conn.execute(f"UPDATE records SET {clause} WHERE id=?",
+                                     [*update_fields.values(), item.record_id])
+                    stats["sn_updated"] += 1
+            except Exception as e:
+                stats["failed"] += 1
+                stats["errors"].append({"side": "sleevenotes", "error": str(e)})
+
+    if new_records:
+        background_tasks.add_task(_refresh_new_records, new_records, hdrs)
+        stats["sn_refreshing"] = len(new_records)
+
+    # Discogs updates — rate limited
+    async with httpx.AsyncClient(timeout=10) as client:
+        for i, item in enumerate(payload.to_discogs):
+            rid = item.discogs_id.lstrip("r")
+            instance_id = item.instance_id
+            folder_id = item.folder_id
+
+            if item.action == "create":
+                try:
+                    add_resp = await discogs_post(
+                        client,
+                        f"https://api.discogs.com/users/{username}/collection/folders/1/releases/{rid}",
+                        headers=hdrs,
+                    )
+                    if add_resp.status_code != 201:
+                        stats["failed"] += 1
+                        stats["errors"].append({"discogs_id": item.discogs_id,
+                                                "error": f"Add failed HTTP {add_resp.status_code}: {add_resp.text[:200]}"})
+                        continue
+                    add_data = add_resp.json()
+                    instance_id = str(add_data["instance_id"])
+                    folder_id = add_data.get("folder_id", 1)
+                    if item.record_id:
+                        with get_db() as conn:
+                            conn.execute("UPDATE records SET instance_id=?, folder_id=? WHERE id=?",
+                                         (instance_id, folder_id, item.record_id))
+                    stats["discogs_created"] += 1
+                except Exception as e:
+                    stats["failed"] += 1
+                    stats["errors"].append({"discogs_id": item.discogs_id, "error": str(e)})
+                    continue
+            else:
+                stats["discogs_updated"] += 1
+                # Back-fill instance_id / folder_id if the record didn't have them
+                if instance_id and item.record_id:
+                    with get_db() as conn:
+                        conn.execute(
+                            "UPDATE records SET instance_id=?, folder_id=? WHERE id=? AND (instance_id IS NULL OR instance_id='')",
+                            (instance_id, folder_id, item.record_id),
+                        )
+
+            if item.updates and instance_id:
+                errs = await _push_field_updates(client, username, hdrs, rid, instance_id, folder_id, item.updates)
+                if errs:
+                    stats["failed"] += len(errs)
+                    stats["errors"].extend(errs)
+            elif item.updates:
+                log.warning("Skipping field updates for %s — instance_id is missing", item.discogs_id)
+
+    return stats
+
+
 # ── Routes: Discogs ───────────────────────────────────────────────────────────
 
 @app.get("/api/discogs/{release_id}")
 async def fetch_discogs(release_id: str):
     rid = release_id.lstrip("r")
+    hdrs = get_discogs_headers()
     async with httpx.AsyncClient(timeout=10) as client:
         release_resp, stats_resp = await asyncio.gather(
-            client.get(f"https://api.discogs.com/releases/{rid}", headers=DISCOGS_HEADERS),
-            client.get(f"https://api.discogs.com/marketplace/stats/{rid}", headers=DISCOGS_HEADERS),
+            discogs_get(client, f"https://api.discogs.com/releases/{rid}", headers=hdrs),
+            discogs_get(client, f"https://api.discogs.com/marketplace/stats/{rid}", headers=hdrs),
         )
     if release_resp.status_code != 200:
         raise HTTPException(status_code=release_resp.status_code, detail="Discogs fetch failed")
     data = release_resp.json()
-    downloaded = await download_all_images(data.get("images", []), f"r{rid}")
+    downloaded = await download_all_images(data.get("images", []), f"r{rid}", hdrs)
     cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=False)
     upsert_tracklist(f"r{rid}", data.get("tracklist", []))
     labels = data.get("labels", [])
@@ -256,17 +780,12 @@ async def fetch_discogs(release_id: str):
 # ── Routes: Records ───────────────────────────────────────────────────────────
 
 @app.get("/api/records")
-def list_records(show_returned: bool = False):
+def list_records():
     try:
         with get_db() as conn:
-            if show_returned:
-                rows = conn.execute(
-                    "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY id"
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT * FROM records WHERE deleted_at IS NULL AND status != 'Returned' ORDER BY id"
-                ).fetchall()
+            rows = conn.execute(
+                "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY CAST(instance_id AS INTEGER), id"
+            ).fetchall()
         return [row_to_dict(r) for r in rows]
     except sqlite3.OperationalError:
         init_db()
@@ -278,12 +797,12 @@ def create_record(rec: RecordIn):
         cur = conn.execute("""
             INSERT INTO records
               (discogs_id,cat_no,artist,title,label,year,format,cover_file,
-               is_new,orig_cond,curr_cond,status,retailer,order_ref,purchase_date,price,pp,notes,valuation)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+               is_new,curr_cond,sleeve_cond,retailer,order_ref,purchase_date,price,pp,notes,valuation)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """, (
             rec.discogs_id, rec.cat_no, rec.artist, rec.title, rec.label,
-            rec.year, rec.format, rec.cover_file, int(rec.is_new),
-            rec.orig_cond, rec.curr_cond, rec.status, rec.retailer,
+            rec.year, rec.format, rec.cover_file, None if rec.is_new is None else int(rec.is_new),
+            rec.curr_cond or None, rec.sleeve_cond or None, rec.retailer,
             rec.order_ref, rec.purchase_date, rec.price, rec.pp, rec.notes, rec.valuation,
         ))
         return {"id": cur.lastrowid}
@@ -294,12 +813,12 @@ def update_record(record_id: int, rec: RecordUpdate):
         conn.execute("""
             UPDATE records SET
               discogs_id=?,cat_no=?,artist=?,title=?,label=?,year=?,format=?,cover_file=?,
-              orig_cond=?,curr_cond=?,status=?,retailer=?,order_ref=?,purchase_date=?,price=?,pp=?,notes=?,valuation=?
+              curr_cond=?,sleeve_cond=?,retailer=?,order_ref=?,purchase_date=?,price=?,pp=?,notes=?,valuation=?
             WHERE id=?
         """, (
             rec.discogs_id, rec.cat_no, rec.artist, rec.title, rec.label,
             rec.year, rec.format, rec.cover_file,
-            rec.orig_cond, rec.curr_cond, rec.status, rec.retailer,
+            rec.curr_cond or None, rec.sleeve_cond or None, rec.retailer,
             rec.order_ref, rec.purchase_date, rec.price, rec.pp, rec.notes, rec.valuation,
             record_id,
         ))
@@ -323,17 +842,18 @@ async def refresh_record(record_id: int):
         raise HTTPException(status_code=404, detail="Record not found")
 
     rid = str(row["discogs_id"]).lstrip("r")
+    hdrs = get_discogs_headers()
     async with httpx.AsyncClient(timeout=10) as client:
         release_resp, stats_resp = await asyncio.gather(
-            client.get(f"https://api.discogs.com/releases/{rid}", headers=DISCOGS_HEADERS),
-            client.get(f"https://api.discogs.com/marketplace/stats/{rid}", headers=DISCOGS_HEADERS),
+            discogs_get(client, f"https://api.discogs.com/releases/{rid}", headers=hdrs),
+            discogs_get(client, f"https://api.discogs.com/marketplace/stats/{rid}", headers=hdrs),
         )
 
     if release_resp.status_code != 200:
         raise HTTPException(status_code=502, detail="Discogs unavailable")
 
     data = release_resp.json()
-    downloaded = await download_all_images(data.get("images", []), f"r{rid}")
+    downloaded = await download_all_images(data.get("images", []), f"r{rid}", hdrs)
     cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=True) or row["cover_file"]
     upsert_tracklist(f"r{rid}", data.get("tracklist", []))
     labels = data.get("labels", [])
@@ -385,10 +905,26 @@ def update_setting(key: str, body: SettingIn):
 
 @app.post("/api/admin/format")
 def format_db():
+    """Delete all records, leaving settings intact."""
     with get_db() as conn:
         conn.execute("DELETE FROM records")
         conn.execute("DELETE FROM tracklist")
         conn.execute("DELETE FROM sqlite_sequence WHERE name='records'")
+    return {"ok": True}
+
+
+@app.post("/api/admin/factory-reset")
+def factory_reset():
+    """Delete all records and restore all settings to their defaults."""
+    with get_db() as conn:
+        conn.execute("DELETE FROM records")
+        conn.execute("DELETE FROM tracklist")
+        conn.execute("DELETE FROM sqlite_sequence WHERE name='records'")
+        for key, value in SETTINGS_DEFAULTS.items():
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (key, value),
+            )
     return {"ok": True}
 
 @app.post("/api/admin/clear-images")
@@ -449,93 +985,140 @@ def set_cover(record_id: int, body: SetCoverIn):
 
 # ── Routes: Import / Export ───────────────────────────────────────────────────
 
-FIELDS = ["id","discogs_id","cat_no","artist","title","label","year","format",
-          "cover_file","is_new","orig_cond","curr_cond","status","retailer","order_ref",
-          "purchase_date","price","pp","notes","valuation"]
+async def _fetch_discogs_field_names(username: str) -> dict[str, str]:
+    """Return {field_id: field_name} from the Discogs fields API, or {} on failure."""
+    if not username:
+        return {}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await discogs_get(
+                client,
+                f"https://api.discogs.com/users/{username}/collection/fields",
+                headers=get_discogs_headers(),
+            )
+        if resp.status_code == 200:
+            return {str(f["id"]): f["name"] for f in resp.json().get("fields", [])}
+    except Exception:
+        pass
+    return {}
 
-CSV_MAP = {
-    # csv column → model field
-    "discogsId": "discogs_id", "catNo": "cat_no", "origCond": "orig_cond",
-    "currCond": "curr_cond", "orderRef": "order_ref", "date": "purchase_date",
-}
 
-@app.post("/api/import")
-async def import_csv(file: UploadFile = File(...)):
-    content = (await file.read()).decode("utf-8")
-    reader = csv.DictReader(io.StringIO(content), delimiter="|")
-    inserted = 0
-    skipped = 0
-    seen_ids = set()
+@app.post("/api/import/csv")
+async def import_csv_discogs(file: UploadFile = File(...)):
+    """Parse a Discogs-format CSV and return a diff preview (same shape as /api/collection/preview)."""
+    content = (await file.read()).decode("utf-8-sig")  # strip BOM if present
     with get_db() as conn:
-        for row in reader:
-            # normalise keys
-            norm = {}
-            for k, v in row.items():
-                mapped = CSV_MAP.get(k, k)
-                norm[mapped] = v.strip() if v else ""
-            # skip if discogs_id missing
-            did = norm.get("discogs_id", "")
-            if not did:
-                continue
-            # dedup by source id if present, otherwise by discogs_id
-            row_id = norm.get("id", "").strip()
-            dedup_key = f"id:{row_id}" if row_id else f"discogs:{did}"
-            if dedup_key in seen_ids:
-                skipped += 1
-                continue
-            seen_ids.add(dedup_key)
-            if row_id:
-                if conn.execute("SELECT 1 FROM records WHERE id = ?", (row_id,)).fetchone():
-                    skipped += 1
-                    continue
-            elif conn.execute("SELECT 1 FROM records WHERE discogs_id = ?", (did,)).fetchone():
-                skipped += 1
-                continue
-            # is_new: treat S (sealed) as new if column absent
-            is_new = norm.get("is_new", "")
-            if is_new == "":
-                is_new = 1 if norm.get("orig_cond", "").upper() == "S" else 0
-            else:
-                is_new = 1 if str(is_new).lower() in ("1", "true", "yes") else 0
-            try:
-                price = float(norm.get("price", 0) or 0)
-                pp = float(norm.get("pp", 0) or 0)
-                year = int(norm.get("year", 0) or 0) or None
-                valuation = float(norm.get("valuation", 0) or 0)
-            except ValueError:
-                price, pp, year, valuation = 0.0, 0.0, None, 0.0
+        rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    settings = {r["key"]: r["value"] for r in rows}
+    username = settings.get("discogs_username", "").strip()
+    try:
+        field_mappings: dict = json.loads(settings.get("discogs_field_mappings", "{}"))
+    except json.JSONDecodeError:
+        field_mappings = {}
 
-            conn.execute("""
-                INSERT INTO records
-                  (discogs_id,cat_no,artist,title,label,year,format,cover_file,
-                   is_new,orig_cond,curr_cond,status,retailer,order_ref,purchase_date,price,pp,notes,valuation)
-                VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-            """, (
-                did, norm.get("cat_no",""), norm.get("artist",""),
-                norm.get("title",""), norm.get("label",""), year,
-                "", norm.get("cover_file","") or find_cached_image(did),
-                is_new, norm.get("orig_cond",""), norm.get("curr_cond",""),
-                norm.get("status","In Collection"), norm.get("retailer",""),
-                norm.get("order_ref",""), normalise_date(norm.get("purchase_date", "")),
-                price, pp, norm.get("notes",""), valuation,
-            ))
-            inserted += 1
-    return {"inserted": inserted, "skipped": skipped}
+    id_to_name = await _fetch_discogs_field_names(username)
+    name_to_db_col: dict[str, str] = {}
+    for field_id, db_col in field_mappings.items():
+        if db_col and field_id in id_to_name:
+            name_to_db_col[id_to_name[field_id]] = db_col
+
+    reader = csv.DictReader(io.StringIO(content))
+    parsed_items: list[dict] = []
+    for row in reader:
+        item = parse_discogs_csv_row(row, name_to_db_col)
+        if item:
+            parsed_items.append(item)
+
+    parsed_items.sort(key=lambda x: int(x.get("instance_id") or 0))
+    diff = compute_diff(parsed_items)
+    diff["db_only"] = []  # CSV import is partial — records absent from the CSV are left untouched
+    return diff
+
+
+# Standard Discogs CSV column name mappings for export
+_EXPORT_STANDARD = [
+    ("discogs_id",  "release_id"),
+    ("folder_id",   "CollectionFolder"),
+    ("cat_no",      "Catalog#"),
+    ("artist",      "Artist"),
+    ("title",       "Title"),
+    ("label",       "Label"),
+    ("format",      "Format"),
+    ("year",        "Released"),
+    ("created_at",  "Date Added"),
+    ("curr_cond",   "Collection Media Condition"),
+    ("sleeve_cond", "Collection Sleeve Condition"),
+]
+_EXPORT_MAPPABLE = ("retailer", "order_ref", "purchase_date", "price", "pp", "notes", "valuation")
+# SN-specific columns appended after all Discogs columns
+_EXPORT_SN_EXTRAS = ("id", "instance_id", "is_new", "cover_file")
+
 
 @app.get("/api/export")
-def export_csv():
+async def export_csv():
     with get_db() as conn:
-        rows = conn.execute("SELECT * FROM records WHERE deleted_at IS NULL ORDER BY id").fetchall()
+        db_rows = conn.execute(
+            "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY CAST(instance_id AS INTEGER), id"
+        ).fetchall()
+        settings_rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    settings = {r["key"]: r["value"] for r in settings_rows}
+    try:
+        field_mappings: dict = json.loads(settings.get("discogs_field_mappings", "{}"))
+    except json.JSONDecodeError:
+        field_mappings = {}
+
+    username = settings.get("discogs_username", "").strip()
+    id_to_name = await _fetch_discogs_field_names(username)
+    # db_col → "Collection [Field Name]" for mapped fields
+    mapped_headers: dict[str, str] = {}
+    for field_id, db_col in field_mappings.items():
+        if db_col:
+            name = id_to_name.get(field_id, field_id)
+            mapped_headers[db_col] = f"Collection {name}"
+
+    # Build ordered column list: standard Discogs cols → mapped custom → unmapped SN → SN extras
+    headers: list[str] = [csv_col for _, csv_col in _EXPORT_STANDARD]
+    for db_col in _EXPORT_MAPPABLE:
+        if db_col in mapped_headers:
+            headers.append(mapped_headers[db_col])
+        else:
+            headers.append(f"SN_{db_col}")
+    headers.extend(f"SN_{col}" for col in _EXPORT_SN_EXTRAS)
+
+    def get_val(d: dict, csv_col: str) -> str:
+        # Reverse-map csv_col → db_col
+        for db_col, col in _EXPORT_STANDARD:
+            if col == csv_col:
+                val = d.get(db_col)
+                if db_col == "discogs_id":
+                    return str(val or "").lstrip("r")
+                return str(val) if val is not None else ""
+        # Mapped custom col
+        for db_col, col in mapped_headers.items():
+            if col == csv_col:
+                val = d.get(db_col)
+                return str(val) if val is not None else ""
+        # Raw DB col (unmapped SN field) — strip SN_ prefix to get the actual db key
+        db_col = csv_col[3:] if csv_col.startswith("SN_") else csv_col
+        val = d.get(db_col)
+        return str(val) if val is not None else ""
+
+    records = [row_to_dict(r) for r in db_rows]
 
     def generate():
-        yield "|".join(FIELDS) + "\n"
-        for row in rows:
-            d = row_to_dict(row)
-            yield "|".join(str(d.get(f, "")) for f in FIELDS) + "\n"
+        buf = io.StringIO()
+        w = csv.writer(buf)
+        w.writerow(headers)
+        yield buf.getvalue()
+        for d in records:
+            buf = io.StringIO()
+            w = csv.writer(buf)
+            w.writerow([get_val(d, h) for h in headers])
+            yield buf.getvalue()
 
     return StreamingResponse(
         generate(),
-        media_type="text/plain",
+        media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=sleevenotes_export.csv"},
     )
 

--- a/compose.yml
+++ b/compose.yml
@@ -6,8 +6,6 @@ services:
       - "2026:2026"
     volumes:
       - data:/data
-    env_file:
-      - sleevenotes.env
     restart: unless-stopped
 
 volumes:

--- a/sleevenotes.env.example
+++ b/sleevenotes.env.example
@@ -1,1 +1,0 @@
-DISCOGS_TOKEN=your_discogs_token_here

--- a/static/index.html
+++ b/static/index.html
@@ -761,8 +761,6 @@
   .toggle input:checked ~ .toggle-thumb { left: 19px; }
 
   /* ── Discogs fetch UI ── */
-  .discogs-fetch-row { display: flex; gap: 0.5rem; }
-  .discogs-fetch-row .form-control { flex: 1; }
 
   .discogs-preview {
     background: var(--surface);
@@ -877,8 +875,7 @@
 </header>
 
 <div class="stats-bar" id="stats-bar">
-  <div class="stat-item"><span class="stat-label">Total Entries</span><span class="stat-value" id="s-total">—</span></div>
-  <div class="stat-item"><span class="stat-label">In Collection</span><span class="stat-value" id="s-col">—</span></div>
+  <div class="stat-item"><span class="stat-label">Total Records</span><span class="stat-value" id="s-total">—</span></div>
   <div class="stat-item"><span class="stat-label">Collection Cost</span><span class="stat-value" id="s-cost">—</span></div>
   <div class="stat-item"><span class="stat-label">Collection Value</span><span class="stat-value" id="s-valuation">—</span></div>
 </div>
@@ -895,13 +892,6 @@
     <span class="search-icon">⌕</span>
     <input type="text" id="search" placeholder="Search artist, title, label…" oninput="renderView()">
   </div>
-
-  <select class="filter" id="filter-status" onchange="renderView()">
-    <option value="">All Statuses</option>
-    <option value="In Collection">In Collection</option>
-    <option value="Purchased">Purchased</option>
-    <option value="Returned">Returned</option>
-  </select>
 
   <div class="toolbar-sep"></div>
 
@@ -930,15 +920,6 @@
       <div class="toggle-thumb"></div>
     </label>
     <span style="font-size:12px;color:var(--ink-light)">Show tags</span>
-  </label>
-
-  <label class="toggle-row" style="cursor:pointer">
-    <label class="toggle">
-      <input type="checkbox" id="show-returned" onchange="onShowReturnedToggle()">
-      <div class="toggle-track"></div>
-      <div class="toggle-thumb"></div>
-    </label>
-    <span style="font-size:12px;color:var(--ink-light)">Show returned</span>
   </label>
 
   <div class="toolbar-sep"></div>
@@ -982,16 +963,22 @@
       <div id="discogs-section">
         <div class="form-group form-full" style="margin-bottom:1rem">
           <label class="form-label">Discogs Release ID</label>
-          <div class="discogs-fetch-row">
-            <input class="form-control" id="f-discogs-id" placeholder="e.g. r36875179 or 36875179">
-            <button class="btn btn-secondary" onclick="fetchDiscogs()" id="fetch-btn">Fetch</button>
+          <input class="form-control" id="f-discogs-id" placeholder="e.g. r36875179 or 36875179">
+          <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+            <button class="btn btn-secondary btn-sm" onclick="fetchDiscogs()" id="fetch-btn">Fetch</button>
+            <button class="btn btn-secondary btn-sm hidden" onclick="syncRecordFields(editingId)" id="sync-fields-btn">Sync Custom Fields</button>
           </div>
-          <div id="discogs-preview" class="hidden"></div>
+          <div id="discogs-preview" class="hidden" style="margin-top:0.5rem"></div>
         </div>
       </div>
 
       <div class="form-grid" id="form-fields">
         <div class="form-section">From Discogs</div>
+
+        <div class="form-group">
+          <label class="form-label">Instance ID</label>
+          <input class="form-control" id="f-instance-id" readonly placeholder="Set after first sync">
+        </div>
 
         <div class="form-group">
           <label class="form-label">Artist</label>
@@ -1030,29 +1017,16 @@
         <div class="form-group">
           <label class="form-label">Purchase Condition</label>
           <select class="form-control" id="f-is-new">
+            <option value="">Unknown</option>
             <option value="0">Pre-Owned</option>
             <option value="1">New</option>
           </select>
         </div>
 
         <div class="form-group">
-          <label class="form-label">Original Grade</label>
-          <select class="form-control" id="f-orig-cond">
-            <option value="S">S — Sealed</option>
-            <option value="M">M — Mint</option>
-            <option value="NM">NM — Near Mint</option>
-            <option value="VG+">VG+ — Very Good Plus</option>
-            <option value="VG">VG — Very Good</option>
-            <option value="G+">G+ — Good Plus</option>
-            <option value="G">G — Good</option>
-            <option value="F">F — Fair</option>
-            <option value="P">P — Poor</option>
-          </select>
-        </div>
-
-        <div class="form-group">
-          <label class="form-label">Current Grade</label>
+          <label class="form-label">Media Condition</label>
           <select class="form-control" id="f-curr-cond">
+            <option value="">Unknown</option>
             <option value="S">S — Sealed</option>
             <option value="M">M — Mint</option>
             <option value="NM">NM — Near Mint</option>
@@ -1066,11 +1040,18 @@
         </div>
 
         <div class="form-group">
-          <label class="form-label">Status</label>
-          <select class="form-control" id="f-status">
-            <option value="In Collection">In Collection</option>
-            <option value="Purchased">Purchased</option>
-            <option value="Returned">Returned</option>
+          <label class="form-label">Sleeve Condition</label>
+          <select class="form-control" id="f-sleeve-cond">
+            <option value="">Unknown</option>
+            <option value="S">S — Sealed</option>
+            <option value="M">M — Mint</option>
+            <option value="NM">NM — Near Mint</option>
+            <option value="VG+">VG+ — Very Good Plus</option>
+            <option value="VG">VG — Very Good</option>
+            <option value="G+">G+ — Good Plus</option>
+            <option value="G">G — Good</option>
+            <option value="F">F — Fair</option>
+            <option value="P">P — Poor</option>
           </select>
         </div>
 
@@ -1120,30 +1101,6 @@
   </div>
 </div>
 
-<!-- ── Import Modal ── -->
-<div class="modal-backdrop" id="modal-import">
-  <div class="modal" style="max-width:480px">
-    <div class="modal-header">
-      <span class="modal-title">Import CSV</span>
-      <button class="btn btn-ghost btn-icon" onclick="closeModal('modal-import')">✕</button>
-    </div>
-    <div class="modal-body">
-      <p style="font-size:13px;color:var(--ink-mid);margin-bottom:1rem">
-        Upload a pipe-delimited CSV. Rows whose Discogs ID already exists in the collection are skipped.
-      </p>
-      <div class="form-group">
-        <label class="form-label">CSV File</label>
-        <input class="form-control" type="file" id="import-file" accept=".csv,.txt">
-      </div>
-      <div id="import-result" style="margin-top:1rem;font-size:13px"></div>
-    </div>
-    <div class="modal-footer">
-      <button class="btn btn-secondary" id="import-cancel-btn" onclick="closeModal('modal-import')">Cancel</button>
-      <button class="btn btn-primary" id="import-submit-btn" onclick="doImport()">Import</button>
-      <button class="btn btn-primary hidden" id="import-close-btn" onclick="closeModal('modal-import')">Close</button>
-    </div>
-  </div>
-</div>
 
 <!-- ── Settings Modal ── -->
 <div class="modal-backdrop" id="modal-settings">
@@ -1155,7 +1112,7 @@
     <div class="modal-body" style="display:flex;flex-direction:column;gap:1rem;">
 
       <div style="border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:0.75rem;">
-        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Display Settings</div>
+        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Display</div>
         <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
           <div>
             <div style="font-size:13px;font-weight:500;color:var(--ink)">Clean artist names</div>
@@ -1170,7 +1127,7 @@
         <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
           <div>
             <div style="font-size:13px;font-weight:500;color:var(--ink)">Include P&amp;P in Collection Cost</div>
-            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">When on, postage &amp; packaging is added to the Collection Cost KPI. Returned records are always excluded.</div>
+            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">When on, postage &amp; packaging is added to the Collection Cost KPI.</div>
           </div>
           <label class="toggle" style="flex-shrink:0" title="Include P&P in Collection Cost">
             <input type="checkbox" id="include-pp-toggle" onchange="onIncludePPToggle()">
@@ -1178,36 +1135,68 @@
             <div class="toggle-thumb"></div>
           </label>
         </div>
-        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
-          <div>
-            <div style="font-size:13px;font-weight:500;color:var(--ink)">Hide obvious format tags</div>
-            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Removes Album, LP, Stereo and Vinyl from format tag display and filters.</div>
+        <div style="display:flex;flex-direction:column;gap:0.4rem;">
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
+            <div>
+              <div style="font-size:13px;font-weight:500;color:var(--ink)">Hide format tags</div>
+              <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Hide tags you're not interested in from the format filter bar.</div>
+            </div>
+            <label class="toggle" style="flex-shrink:0" title="Hide format tags">
+              <input type="checkbox" id="hide-format-tags-toggle" onchange="onHideFormatTagsToggle()">
+              <div class="toggle-track"></div>
+              <div class="toggle-thumb"></div>
+            </label>
           </div>
-          <label class="toggle" style="flex-shrink:0" title="Hide obvious format tags">
-            <input type="checkbox" id="hide-obvious-formats-toggle" onchange="onHideObviousFormatsToggle()">
-            <div class="toggle-track"></div>
-            <div class="toggle-thumb"></div>
-          </label>
+          <input class="form-control" id="hidden-format-tags-input" placeholder="e.g. Album, LP, Stereo, Vinyl" onchange="onHiddenTagsChange()">
         </div>
       </div>
 
       <div style="border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:0.75rem;">
-        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Data</div>
-        <div style="display:flex;gap:0.5rem;">
-          <button class="btn btn-secondary btn-sm" onclick="closeModal('modal-settings');openImport()">Import from CSV</button>
-          <button class="btn btn-secondary btn-sm" onclick="doExport()">Export to CSV</button>
+        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Discogs</div>
+        <div class="form-group" style="margin:0">
+          <label class="form-label">Username</label>
+          <input class="form-control" id="settings-discogs-username" placeholder="Your Discogs username">
         </div>
-      </div>
-
-      <div style="border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:0.75rem;">
-        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Fetch All from Discogs</div>
-        <div style="font-size:12px;color:var(--ink-light)">Re-fetches metadata and valuations for existing records. Preserves purchase details. Runs 5 records concurrently (2 API calls each), ~30 records per minute.</div>
+        <div class="form-group" style="margin:0">
+          <label class="form-label">API Token</label>
+          <input class="form-control" type="password" id="settings-discogs-token" placeholder="••••••••••••••••">
+        </div>
+        <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
+        <div>
+          <div style="font-size:13px;font-weight:500;color:var(--ink)">Refresh Metadata</div>
+          <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Re-fetches Discogs-sourced fields (artist, label, format, valuation) for records already in SleeveNotes. Your purchase details, condition and notes are never touched. ~30 records per minute.</div>
+        </div>
         <div id="fetch-range-btns" style="display:flex;flex-wrap:wrap;gap:0.5rem;"></div>
         <div id="fetch-progress" class="hidden" style="display:flex;flex-direction:column;gap:0.4rem;">
           <div style="font-size:12px;color:var(--ink-mid)" id="fetch-progress-label">Fetching…</div>
           <div style="height:6px;background:var(--border);border-radius:3px;overflow:hidden">
             <div id="fetch-progress-bar" style="height:100%;background:var(--green);width:0%;transition:width 0.3s"></div>
           </div>
+        </div>
+        <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
+        <div>
+          <div style="font-size:13px;font-weight:500;color:var(--ink)">Field Mapping</div>
+          <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Map your Discogs custom fields to SleeveNotes fields. Changes are saved with the Save button above.</div>
+        </div>
+        <div id="settings-mapping-loading" style="font-size:12px;color:var(--ink-light)">Loading…</div>
+        <div id="settings-mapping-section" style="display:none">
+          <div id="discogs-fields-rows"></div>
+        </div>
+        <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
+        <div>
+          <div style="font-size:13px;font-weight:500;color:var(--ink)">Sync Collection</div>
+          <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Two-way sync between SleeveNotes and your Discogs collection. Shows a full diff — choose per record which direction to sync, or skip.</div>
+        </div>
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+          <button class="btn btn-secondary btn-sm" onclick="openDiscogsSync()">Sync with Discogs…</button>
+        </div>
+      </div>
+
+      <div style="border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:0.75rem;">
+        <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Data</div>
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+          <label class="btn btn-secondary btn-sm" style="cursor:pointer">Import from CSV<input type="file" accept=".csv" style="display:none" onchange="importCsv(this)"></label>
+          <button class="btn btn-secondary btn-sm" onclick="doExport()">Export to CSV</button>
         </div>
       </div>
 
@@ -1219,10 +1208,10 @@
 
         <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
           <div>
-            <div style="font-size:13px;font-weight:500;color:var(--ink)">Format Database</div>
-            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Permanently deletes all records. Cannot be undone.</div>
+            <div style="font-size:13px;font-weight:500;color:var(--ink)">Delete All Records</div>
+            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Permanently deletes all records. Settings and field mappings are preserved. Cannot be undone.</div>
           </div>
-          <label class="toggle" title="Enable to unlock">
+          <label class="toggle" style="flex-shrink:0" title="Enable to unlock">
             <input type="checkbox" id="format-safety-toggle" onchange="onFormatToggle()">
             <div class="toggle-track"></div>
             <div class="toggle-thumb"></div>
@@ -1230,6 +1219,22 @@
         </div>
 
         <button class="btn btn-danger" id="format-db-btn" disabled onclick="doFormatDb()" style="align-self:flex-start;opacity:0.4;cursor:not-allowed">
+          Delete All Records
+        </button>
+
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
+          <div>
+            <div style="font-size:13px;font-weight:500;color:var(--ink)">Format Database</div>
+            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Deletes all records and resets all settings — Discogs token, username, field mappings and display preferences — back to defaults. Cannot be undone.</div>
+          </div>
+          <label class="toggle" style="flex-shrink:0" title="Enable to unlock">
+            <input type="checkbox" id="factory-reset-safety-toggle" onchange="onFactoryResetToggle()">
+            <div class="toggle-track"></div>
+            <div class="toggle-thumb"></div>
+          </label>
+        </div>
+
+        <button class="btn btn-danger" id="factory-reset-btn" disabled onclick="doFactoryReset()" style="align-self:flex-start;opacity:0.4;cursor:not-allowed">
           Format Database
         </button>
 
@@ -1238,7 +1243,7 @@
             <div style="font-size:13px;font-weight:500;color:var(--ink)">Clear Image Cache</div>
             <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Deletes all cached cover images from disk. Cannot be undone.</div>
           </div>
-          <label class="toggle" title="Enable to unlock">
+          <label class="toggle" style="flex-shrink:0" title="Enable to unlock">
             <input type="checkbox" id="clear-images-safety-toggle" onchange="onClearImagesToggle()">
             <div class="toggle-track"></div>
             <div class="toggle-thumb"></div>
@@ -1253,6 +1258,27 @@
     </div>
     <div class="modal-footer">
       <button class="btn btn-secondary" onclick="closeModal('modal-settings')">Close</button>
+      <button class="btn btn-primary" onclick="saveSettings()">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Discogs Sync — Preview Modal ── -->
+<div class="modal-backdrop" id="modal-discogs-sync">
+  <div class="modal" style="max-width:680px">
+    <div class="modal-header">
+      <span class="modal-title">Sync Preview</span>
+      <button class="btn btn-ghost btn-icon" onclick="closeModal('modal-discogs-sync')">✕</button>
+    </div>
+    <div class="modal-body">
+      <div id="sync-preview-loading" style="text-align:center;padding:2rem;color:var(--ink-light);font-size:13px">
+        Loading…
+      </div>
+      <div id="sync-preview-content" style="display:none"></div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal('modal-discogs-sync')">Cancel</button>
+      <button class="btn btn-primary" id="sync-apply-btn" onclick="applySync()" disabled>Apply Sync</button>
     </div>
   </div>
 </div>
@@ -1271,7 +1297,7 @@ let sortDir = null;
 let cleanArtists = true;
 let includePP = false;
 let hideObviousFormats = true;
-const OBVIOUS_FORMATS = new Set(['Album', 'LP', 'Stereo', 'Vinyl']);
+let hiddenFormatTags = new Set(['Album', 'LP', 'Stereo', 'Vinyl']);
 let filterFormat = null; // active format tag string, or null
 let selectedTileId = null;
 let showValuations = false;
@@ -1300,9 +1326,6 @@ function restoreLocalState() {
   showTags = lsGet('showTags', false);
   document.getElementById('show-tags').checked = showTags;
 
-  const showReturned = lsGet('showReturned', false);
-  document.getElementById('show-returned').checked = showReturned;
-
   const groupByArtist = lsGet('groupByArtist', false);
   document.getElementById('group-by-artist').checked = groupByArtist;
 
@@ -1323,11 +1346,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('modal-form').addEventListener('click', e => {
     if (e.target === e.currentTarget) closeModal('modal-form');
   });
-  document.getElementById('modal-import').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-import');
-  });
-  document.getElementById('modal-settings').addEventListener('click', e => {
+document.getElementById('modal-settings').addEventListener('click', e => {
     if (e.target === e.currentTarget) closeModal('modal-settings');
+  });
+  document.getElementById('modal-discogs-sync').addEventListener('click', e => {
+    if (e.target === e.currentTarget) closeModal('modal-discogs-sync');
   });
   document.getElementById('main-content').addEventListener('click', e => {
     if (e.target.closest('a, button, .fmt-tag-filter')) return;
@@ -1337,6 +1360,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 // ── Data ───────────────────────────────────────────────────────────────────
+let discogsUsername = '';
+let discogsFieldMappings = {};
+let discogsFields = [];
+let diffData = null;
+let syncSource = 'discogs'; // 'discogs' | 'csv'
+
 async function loadSettings() {
   try {
     const r = await fetch('/api/settings');
@@ -1345,14 +1374,18 @@ async function loadSettings() {
       if (s.clean_artists !== undefined) cleanArtists = s.clean_artists === 'true';
       if (s.include_pp !== undefined) includePP = s.include_pp === 'true';
       if (s.hide_obvious_formats !== undefined) hideObviousFormats = s.hide_obvious_formats === 'true';
+      if (s.hidden_format_tags !== undefined)
+        hiddenFormatTags = new Set(s.hidden_format_tags.split(',').map(t => t.trim()).filter(Boolean));
+      discogsUsername = s.discogs_username || '';
+      try { discogsFieldMappings = JSON.parse(s.discogs_field_mappings || '{}'); } catch { discogsFieldMappings = {}; }
+      // token is not surfaced to JS state — it stays in the DB and is read server-side
     }
   } catch {}
 }
 
 async function loadRecords() {
-  const showReturned = document.getElementById('show-returned').checked;
   try {
-    const r = await fetch(`/api/records?show_returned=${showReturned}`);
+    const r = await fetch('/api/records');
     if (!r.ok) throw new Error(r.status);
     records = await r.json();
     renderView();
@@ -1375,13 +1408,23 @@ function updateRetailersList() {
     .join('');
 }
 
+function startCoverPoll(refreshingCount) {
+  // Poll every 8s until all refreshing records have a cover_file, or 40 attempts (~5 min).
+  // Uses covers-before as baseline so pre-existing no-cover records don't stall the loop.
+  const baseline = records.filter(r => r.cover_file).length;
+  let polls = 0;
+  const id = setInterval(async () => {
+    polls++;
+    await loadRecords();
+    const covered = records.filter(r => r.cover_file).length - baseline;
+    if (covered >= refreshingCount || polls >= 40) clearInterval(id);
+  }, 8000);
+}
+
 function updateStats() {
-  const inCol = records.filter(r => r.status === 'In Collection').length;
-  const notReturned = records.filter(r => r.status !== 'Returned');
-  const cost = notReturned.reduce((s,r) => s + (r.price||0) + (includePP ? (r.pp||0) : 0), 0);
+  const cost = records.reduce((s,r) => s + (r.price||0) + (includePP ? (r.pp||0) : 0), 0);
   const valuation = records.reduce((s,r) => s + (r.valuation||0), 0);
   document.getElementById('s-total').textContent = records.length;
-  document.getElementById('s-col').textContent = inCol;
   document.getElementById('s-cost').textContent = showValuations ? '£' + cost.toFixed(2) : '—';
   document.getElementById('s-valuation').textContent = showValuations && valuation ? '£' + valuation.toFixed(2) : '—';
 }
@@ -1395,9 +1438,7 @@ function onShowValuationsToggle() {
 // ── Filtering & sorting ────────────────────────────────────────────────────
 function getFiltered() {
   const q = document.getElementById('search').value.toLowerCase().trim();
-  const fs = document.getElementById('filter-status').value;
   return records.filter(r => {
-    if (fs && r.status !== fs) return false;
     if (filterFormat && !formatTags(r.format, false).includes(filterFormat)) return false;
     if (q) {
       const hay = `${r.artist} ${r.title} ${r.label} ${r.cat_no} ${r.retailer}`.toLowerCase();
@@ -1417,7 +1458,6 @@ function applySortCol(rows) {
       case 'title':     v = cmp(a.title, b.title); break;
       case 'label':     v = cmp(a.label, b.label); break;
       case 'year':      v = cmpN(a.year, b.year); break;
-      case 'status':    v = cmp(a.status, b.status); break;
       case 'retailer':  v = cmp(a.retailer, b.retailer); break;
       case 'purchase_date': {
         const da = a.purchase_date || '', db = b.purchase_date || '';
@@ -1450,7 +1490,7 @@ const cmpN = (a, b) => (a||0) - (b||0);
 
 // ── View switching ─────────────────────────────────────────────────────────
 function openRandom() {
-  const pool = records.filter(r => r.status === 'In Collection');
+  const pool = records;
   if (!pool.length) { toast('No records in collection', 'error'); return; }
   const pick = pool[Math.floor(Math.random() * pool.length)];
   openDetail(pick.id);
@@ -1483,10 +1523,6 @@ function onShowTagsToggle() {
   updateFormatFilterBar();
 }
 
-function onShowReturnedToggle() {
-  lsSet('showReturned', document.getElementById('show-returned').checked);
-  loadRecords();
-}
 
 function onGroupByArtistToggle() {
   lsSet('groupByArtist', document.getElementById('group-by-artist').checked);
@@ -1507,10 +1543,9 @@ function rowHtml(r) {
     <td class="text-mono col-sm">${r.year||''}</td>
     <td class="col-sm" style="white-space:nowrap">${fmtTagsCell(r.format)}</td>
     <td class="col-sm">
-      <span class="${r.is_new ? 'badge badge-new' : 'badge badge-used'}">${r.is_new ? 'New' : 'Pre-Owned'}</span>
-      <span style="font-size:10px;color:var(--ink-light);margin-left:4px">${esc(r.orig_cond)}/${esc(r.curr_cond)}</span>
+      ${r.is_new !== null && r.is_new !== undefined ? `<span class="${r.is_new ? 'badge badge-new' : 'badge badge-used'}">${r.is_new ? 'New' : 'Pre-Owned'}</span>` : ''}
+      <span style="font-size:10px;color:var(--ink-light);margin-left:4px">${esc(r.curr_cond||'—')}/${esc(r.sleeve_cond||'—')}</span>
     </td>
-    <td class="col-sm"><span class="badge ${statusClass(r.status)}">${esc(r.status)}</span></td>
     <td class="col-md">${esc(r.retailer)}</td>
     <td class="text-mono col-md">${fmtDate(r.purchase_date)}</td>
     <td class="text-mono text-right col-sm">£${(r.price||0).toFixed(2)}</td>
@@ -1567,7 +1602,6 @@ function renderTable() {
             ${th('year',          'Year',          'col-sm')}
             <th class="col-sm">Format</th>
             <th class="col-sm">Cond.</th>
-            ${th('status',        'Status',        'col-sm')}
             ${th('retailer',      'Retailer',      'col-md')}
             ${th('purchase_date', 'Purchase Date', 'col-md')}
             ${th('price',         'Price',         'col-sm text-right')}
@@ -1651,15 +1685,14 @@ async function openDetail(id) {
           <div class="detail-artist">${esc(displayArtist(r.artist))}</div>
           <div class="detail-title">${esc(r.title)}</div>
           <div class="detail-meta">
-            <span class="badge ${statusClass(r.status)}">${esc(r.status)}</span>
-            <span class="${r.is_new ? 'badge badge-new' : 'badge badge-used'}">${r.is_new ? 'New' : 'Pre-Owned'}</span>
+            ${r.is_new !== null && r.is_new !== undefined ? `<span class="${r.is_new ? 'badge badge-new' : 'badge badge-used'}">${r.is_new ? 'New' : 'Pre-Owned'}</span>` : ''}
           </div>
           <div class="detail-row"><span class="detail-key">Label</span><span class="detail-val">${esc(r.label)||'—'}</span></div>
           <div class="detail-row"><span class="detail-key">Cat No.</span><span class="detail-val">${esc(r.cat_no)||'—'}</span></div>
           <div class="detail-row"><span class="detail-key">Year</span><span class="detail-val">${r.year||'—'}</span></div>
           <div class="detail-row"><span class="detail-key">Format</span><span class="detail-val">${fmtTagsHtml(r.format)||'—'}</span></div>
-          <div class="detail-row"><span class="detail-key">Purchased</span><span class="detail-val">${esc(condLabel(r.orig_cond))}</span></div>
-          <div class="detail-row"><span class="detail-key">Current</span><span class="detail-val">${esc(condLabel(r.curr_cond))}</span></div>
+          <div class="detail-row"><span class="detail-key">Media</span><span class="detail-val">${esc(condLabel(r.curr_cond))}</span></div>
+          <div class="detail-row"><span class="detail-key">Sleeve</span><span class="detail-val">${esc(condLabel(r.sleeve_cond))}</span></div>
           <div class="detail-row"><span class="detail-key">Retailer</span><span class="detail-val">${esc(r.retailer)||'—'}</span></div>
           <div class="detail-row"><span class="detail-key">Order Ref</span><span class="detail-val">${esc(r.order_ref)||'—'}</span></div>
           <div class="detail-row"><span class="detail-key">Purchase Date</span><span class="detail-val">${fmtDate(r.purchase_date)||'—'}</span></div>
@@ -1809,6 +1842,7 @@ function openAdd() {
   document.getElementById('discogs-section').style.display = '';
   document.getElementById('fetch-btn').textContent = 'Fetch';
   document.getElementById('delete-btn').classList.add('hidden');
+  document.getElementById('sync-fields-btn').classList.add('hidden');
   resetForm();
   openModal('modal-form');
 }
@@ -1821,11 +1855,13 @@ function openEdit(id) {
 
   document.getElementById('form-modal-title').textContent = 'Edit Record';
   document.getElementById('discogs-section').style.display = '';
-  document.getElementById('fetch-btn').textContent = 'Re-fetch';
+  document.getElementById('fetch-btn').textContent = 'Sync Metadata';
+  document.getElementById('sync-fields-btn').classList.remove('hidden');
   document.getElementById('discogs-preview').classList.add('hidden');
   document.getElementById('delete-btn').classList.remove('hidden');
 
   setField('f-discogs-id', r.discogs_id);
+  setField('f-instance-id', r.instance_id || '');
   setField('f-artist', r.artist);
   setField('f-title', r.title);
   setField('f-label', r.label);
@@ -1839,26 +1875,24 @@ function openEdit(id) {
   setField('f-price', (r.price||0).toFixed(2));
   setField('f-pp', (r.pp||0).toFixed(2));
   setField('f-notes', r.notes);
-  document.getElementById('f-is-new').value = r.is_new ? '1' : '0';
-  document.getElementById('f-status').value = r.status;
-  document.getElementById('f-orig-cond').value = r.orig_cond || 'NM';
-  document.getElementById('f-curr-cond').value = r.curr_cond || 'NM';
+  document.getElementById('f-is-new').value = r.is_new === null || r.is_new === undefined ? '' : (r.is_new ? '1' : '0');
+  document.getElementById('f-curr-cond').value = r.curr_cond || '';
+  document.getElementById('f-sleeve-cond').value = r.sleeve_cond || '';
 
   openModal('modal-form');
 }
 
 function resetForm() {
-  ['f-discogs-id','f-artist','f-title','f-label','f-cat-no','f-format',
+  ['f-discogs-id','f-instance-id','f-artist','f-title','f-label','f-cat-no','f-format',
    'f-retailer','f-order-ref','f-notes'].forEach(id => setField(id, ''));
   setField('f-valuation', '0.00');
   setField('f-year', '');
   setField('f-price', '0.00');
   setField('f-pp', '0.00');
   setField('f-purchase-date', new Date().toISOString().split('T')[0]);
-  document.getElementById('f-is-new').value = '0';
-  document.getElementById('f-status').value = 'In Collection';
-  document.getElementById('f-orig-cond').value = 'NM';
-  document.getElementById('f-curr-cond').value = 'NM';
+  document.getElementById('f-is-new').value = '';
+  document.getElementById('f-curr-cond').value = '';
+  document.getElementById('f-sleeve-cond').value = '';
   document.getElementById('discogs-preview').classList.add('hidden');
 }
 
@@ -1911,10 +1945,9 @@ async function saveRecord() {
     year: parseInt(val('f-year'))||null,
     format: val('f-format'),
     cover_file: fetchedMeta.cover_file || '',
-    is_new: document.getElementById('f-is-new').value === '1',
-    orig_cond: val('f-orig-cond'),
+    is_new: document.getElementById('f-is-new').value === '' ? null : document.getElementById('f-is-new').value === '1',
     curr_cond: val('f-curr-cond'),
-    status: val('f-status'),
+    sleeve_cond: val('f-sleeve-cond'),
     retailer: val('f-retailer'),
     order_ref: val('f-order-ref'),
     purchase_date: val('f-purchase-date'),
@@ -1964,33 +1997,23 @@ async function deleteRecord() {
 }
 
 // ── Import / Export ────────────────────────────────────────────────────────
-function openImport() {
-  document.getElementById('import-file').value = '';
-  document.getElementById('import-result').innerHTML = '';
-  document.getElementById('import-cancel-btn').classList.remove('hidden');
-  document.getElementById('import-submit-btn').classList.remove('hidden');
-  document.getElementById('import-close-btn').classList.add('hidden');
-  openModal('modal-import');
-}
-
-async function doImport() {
-  const file = document.getElementById('import-file').files[0];
-  if (!file) { toast('Select a file first', 'error'); return; }
-  const fd = new FormData();
-  fd.append('file', file);
-  const res = document.getElementById('import-result');
-  res.textContent = 'Importing…';
+async function importCsv(input) {
+  const file = input.files[0];
+  input.value = '';
+  if (!file) return;
+  toast('Parsing CSV…');
+  closeModal('modal-settings');
   try {
-    const r = await fetch('/api/import', { method: 'POST', body: fd });
-    const d = await r.json();
-    const skippedNote = d.skipped ? `, ${d.skipped} already existed` : '';
-    res.innerHTML = `<span style="color:var(--green)">✓ Imported ${d.inserted} record${d.inserted !== 1 ? 's' : ''}${skippedNote}</span>`;
-    await loadRecords();
-    document.getElementById('import-cancel-btn').classList.add('hidden');
-    document.getElementById('import-submit-btn').classList.add('hidden');
-    document.getElementById('import-close-btn').classList.remove('hidden');
-  } catch {
-    res.innerHTML = `<span style="color:var(--red)">Import failed</span>`;
+    const fd = new FormData();
+    fd.append('file', file);
+    const resp = await fetch('/api/import/csv', { method: 'POST', body: fd });
+    if (!resp.ok) throw new Error((await resp.json()).detail || resp.status);
+    diffData = await resp.json();
+    syncSource = 'csv';
+    openSyncModal();
+    renderSyncPreview(diffData);
+  } catch(e) {
+    toast('CSV import failed: ' + e.message, 'error');
   }
 }
 
@@ -1998,47 +2021,446 @@ function doExport() {
   window.location.href = '/api/export';
 }
 
+// ── Discogs Sync ──────────────────────────────────────────────────────────────
+const DISCOGS_DB_COLS = [
+  ['purchase_date', 'Purchase Date'],
+  ['price', 'Price (£)'],
+  ['pp', 'P&P (£)'],
+  ['retailer', 'Retailer'],
+  ['order_ref', 'Order Ref'],
+  ['curr_cond', 'Media Condition'],
+  ['sleeve_cond', 'Sleeve Condition'],
+  ['notes', 'Notes'],
+];
+
+const CONDITION_TO_DISCOGS = {
+  'M':   'Mint (M)',
+  'NM':  'Near Mint (NM or M-)',
+  'VG+': 'Very Good Plus (VG+)',
+  'VG':  'Very Good (VG)',
+  'G+':  'Good Plus (G+)',
+  'G':   'Good (G)',
+  'F':   'Fair (F)',
+  'P':   'Poor (P)',
+};
+
+function formatExportValue(dbCol, value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (dbCol === 'purchase_date') return value ? fmtDate(value) : null;
+  if (dbCol === 'price' || dbCol === 'pp') {
+    const n = parseFloat(value);
+    return (n && n > 0) ? n.toFixed(2) : null;
+  }
+  if (dbCol === 'curr_cond' || dbCol === 'sleeve_cond') {
+    return CONDITION_TO_DISCOGS[String(value).trim()] || String(value).trim() || null;
+  }
+  return String(value).trim() || null;
+}
+
+function buildFieldUpdates(record, limitToCols = null) {
+  return Object.entries(discogsFieldMappings)
+    .filter(([, col]) => col && (!limitToCols || limitToCols.has(col)))
+    .map(([fid, col]) => {
+      const value = formatExportValue(col, record[col]);
+      if (value === null) return null;
+      const field = discogsFields.find(f => String(f.id) === fid);
+      if (field?.type === 'dropdown' && Array.isArray(field.options) && !field.options.includes(value)) {
+        return null;
+      }
+      return { field_id: fid, value };
+    })
+    .filter(u => u !== null);
+}
+
+function getDropdownSkips(record, limitToCols = null) {
+  const skips = [];
+  Object.entries(discogsFieldMappings).forEach(([fid, col]) => {
+    if (!col) return;
+    if (limitToCols && !limitToCols.has(col)) return;
+    const value = formatExportValue(col, record[col]);
+    if (value === null) return;
+    const field = discogsFields.find(f => String(f.id) === fid);
+    if (field?.type === 'dropdown' && Array.isArray(field.options) && !field.options.includes(value)) {
+      skips.push({ fieldName: field.name || col, value });
+    }
+  });
+  return skips;
+}
+
+async function loadDiscogsFields() {
+  const loading = document.getElementById('settings-mapping-loading');
+  const section = document.getElementById('settings-mapping-section');
+  if (loading) loading.style.display = '';
+  if (section) section.style.display = 'none';
+  try {
+    const resp = await fetch('/api/collection/fields');
+    if (!resp.ok) throw new Error((await resp.json()).detail || resp.status);
+    const data = await resp.json();
+    discogsFields = data.fields || [];
+    renderFieldMappings(discogsFields, discogsFieldMappings);
+    if (loading) loading.style.display = 'none';
+    if (section) section.style.display = '';
+  } catch(e) {
+    if (loading) loading.textContent = 'Could not load Discogs fields — check username and token.';
+  }
+}
+
+async function openDiscogsSync() {
+  if (!discogsUsername) {
+    toast('Set your Discogs username in Settings first', 'error');
+    return;
+  }
+  closeModal('modal-settings');
+  if (!discogsFields.length) await loadDiscogsFields();
+  await previewSync();
+}
+
+function openSyncModal(loadingText = 'Fetching your Discogs collection…') {
+  document.getElementById('sync-preview-loading').textContent = loadingText;
+  document.getElementById('sync-preview-loading').style.display = '';
+  document.getElementById('sync-preview-content').style.display = 'none';
+  document.getElementById('sync-apply-btn').disabled = true;
+  document.getElementById('sync-apply-btn').textContent = 'Apply Sync';
+  openModal('modal-discogs-sync');
+}
+
+function renderFieldMappings(fields, currentMappings) {
+  const rows = document.getElementById('discogs-fields-rows');
+  const byDbCol = {};
+  Object.entries(currentMappings).forEach(([fid, col]) => { if (col) byDbCol[col] = fid; });
+  const fieldOptions = [['', '— Not mapped —'], ...fields.map(f => [String(f.id), f.name])];
+  rows.innerHTML = DISCOGS_DB_COLS.map(([dbCol, label]) => {
+    const current = byDbCol[dbCol] || '';
+    const options = fieldOptions.map(([v, name]) =>
+      `<option value="${v}"${v === current ? ' selected' : ''}>${esc(name)}</option>`
+    ).join('');
+    return `<div style="display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0;border-bottom:1px solid var(--border)">
+      <span style="flex:1;font-size:13px">${esc(label)}</span>
+      <select class="form-control" style="width:200px;padding:0.25rem 0.5rem" data-db-col="${dbCol}">${options}</select>
+    </div>`;
+  }).join('');
+}
+
+async function previewSync(recordId = null) {
+  syncSource = 'discogs';
+  openSyncModal();
+  try {
+    const url = recordId ? `/api/collection/preview?record_id=${recordId}` : '/api/collection/preview';
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error((await resp.json()).detail || resp.status);
+    diffData = await resp.json();
+    renderSyncPreview(diffData);
+  } catch(e) {
+    toast('Preview failed: ' + e.message, 'error');
+    closeModal('modal-discogs-sync');
+  }
+}
+
+async function syncRecordFields(id) {
+  if (!id) return;
+  if (!discogsUsername) { toast('Set your Discogs username in Settings first', 'error'); return; }
+  if (!discogsFields.length) await loadDiscogsFields();
+  await previewSync(id);
+}
+
+function renderSyncPreview(diff) {
+  document.getElementById('sync-preview-loading').style.display = 'none';
+  const content = document.getElementById('sync-preview-content');
+  content.style.display = '';
+  let html = '';
+
+  if (diff.new.length) {
+    const newLabel = syncSource === 'csv' ? 'New from CSV' : 'New from Discogs';
+    html += `<div style="margin-bottom:1.25rem">
+      <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--green);font-weight:500;margin-bottom:0.5rem">${newLabel} (${diff.new.length})</div>`;
+    diff.new.forEach((r, i) => {
+      html += `<label style="display:flex;align-items:center;gap:0.5rem;padding:0.35rem 0;border-bottom:1px solid var(--border);cursor:pointer">
+        <input type="checkbox" class="sync-new-check" data-idx="${i}" checked>
+        <span style="font-size:13px"><strong>${esc(r.artist)}</strong> — ${esc(r.title)}${r.year ? ` (${r.year})` : ''}</span>
+        <span style="font-size:11px;color:var(--green);margin-left:auto;flex-shrink:0">→ SleeveNotes</span>
+      </label>`;
+    });
+    html += '</div>';
+  }
+
+  if (diff.changed.length) {
+    html += `<div style="margin-bottom:1.25rem">
+      <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--gold);font-weight:500;margin-bottom:0.5rem">Differences (${diff.changed.length})</div>`;
+    diff.changed.forEach((r, i) => {
+      const changeList = Object.entries(r.changes).map(([col, {from, to}]) => {
+        const fromStr = (from !== null && from !== undefined && String(from).trim()) ? esc(String(from)) : '—';
+        const toStr = (to !== null && to !== undefined && String(to).trim())
+          ? `<strong>${esc(String(to))}</strong>`
+          : `<strong style="color:var(--red)">[Deleted]</strong>`;
+        return `<span style="font-size:11px;color:var(--ink-light)">${esc(col)}: <em>${fromStr}</em> → ${toStr}</span>`;
+      }).join(' &nbsp;·&nbsp; ');
+      const changedCols = new Set(Object.keys(r.changes));
+      const skips = getDropdownSkips(r.current, changedCols);
+      const skipNote = skips.length
+        ? `<div style="font-size:11px;color:var(--gold);margin-top:0.3rem">⚠ ${skips.map(s => `${esc(s.fieldName)} ("${esc(s.value)}" not in Discogs dropdown)`).join(', ')} will be skipped</div>`
+        : '';
+      html += `<div style="padding:0.5rem 0;border-bottom:1px solid var(--border)">
+        <div style="font-size:13px;margin-bottom:0.25rem"><strong>${esc(r.current.artist)}</strong> — ${esc(r.current.title)}</div>
+        <div style="margin-bottom:0.4rem">${changeList}</div>
+        <div style="display:flex;gap:1rem;align-items:center">
+          <label style="display:flex;align-items:center;gap:0.3rem;font-size:12px;cursor:pointer">
+            <input type="radio" name="sync-changed-${i}" class="sync-changed-radio" data-idx="${i}" value="to_sleevenotes"${syncSource === 'csv' ? ' checked' : ''}> ← SleeveNotes
+          </label>
+          <label style="display:flex;align-items:center;gap:0.3rem;font-size:12px;cursor:pointer">
+            <input type="radio" name="sync-changed-${i}" class="sync-changed-radio" data-idx="${i}" value="skip"${syncSource !== 'csv' ? ' checked' : ''}> Skip
+          </label>
+          ${syncSource !== 'csv' ? `<label style="display:flex;align-items:center;gap:0.3rem;font-size:12px;cursor:pointer">
+            <input type="radio" name="sync-changed-${i}" class="sync-changed-radio" data-idx="${i}" value="to_discogs"> Discogs →
+          </label>` : ''}
+        </div>
+        ${skipNote}
+      </div>`;
+    });
+    html += '</div>';
+  }
+
+  const pushable = diff.db_only.filter(r => r.discogs_id);
+  const noId = diff.db_only.filter(r => !r.discogs_id);
+
+  if (pushable.length) {
+    html += `<div style="margin-bottom:1.25rem">
+      <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--blue);font-weight:500;margin-bottom:0.5rem">Only in SleeveNotes (${pushable.length})</div>`;
+    pushable.forEach((r, i) => {
+      const skips = getDropdownSkips(r);
+      const skipNote = skips.length
+        ? `<div style="font-size:11px;color:var(--gold);margin-top:0.15rem">⚠ ${skips.map(s => `${esc(s.fieldName)} ("${esc(s.value)}" not in Discogs dropdown)`).join(', ')} will be skipped</div>`
+        : '';
+      html += `<div style="padding:0.35rem 0;border-bottom:1px solid var(--border)">
+        <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer">
+          <input type="checkbox" class="sync-push-check" data-idx="${i}" data-record-id="${r.id}">
+          <span style="font-size:13px"><strong>${esc(r.artist)}</strong> — ${esc(r.title)}${r.year ? ` (${r.year})` : ''}</span>
+          <span style="font-size:11px;color:var(--blue);margin-left:auto;flex-shrink:0">→ Discogs</span>
+        </label>
+        ${skipNote}
+      </div>`;
+    });
+    html += '</div>';
+  }
+
+  if (noId.length) {
+    html += `<div style="margin-bottom:1.25rem">
+      <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500;margin-bottom:0.5rem">No Discogs ID — cannot sync (${noId.length})</div>`;
+    noId.slice(0, 5).forEach(r => {
+      html += `<div style="font-size:12px;color:var(--ink-light);padding:0.25rem 0">${esc(r.artist)} — ${esc(r.title)}</div>`;
+    });
+    if (noId.length > 5) html += `<div style="font-size:12px;color:var(--ink-light)">…and ${noId.length - 5} more</div>`;
+    html += '</div>';
+  }
+
+  if (diff.unchanged.length) {
+    html += `<div style="font-size:12px;color:var(--ink-light);margin-bottom:0.75rem">${diff.unchanged.length} record${diff.unchanged.length === 1 ? '' : 's'} unchanged</div>`;
+  }
+
+  if (!diff.new.length && !diff.changed.length && !pushable.length) {
+    html += `<div style="font-size:13px;color:var(--ink-light);text-align:center;padding:1.5rem 0">Everything is in sync.</div>`;
+  }
+
+  content.innerHTML = html;
+  content.addEventListener('change', updateSyncApplyBtn);
+  updateSyncApplyBtn();
+}
+
+function updateSyncApplyBtn() {
+  const newChecked = document.querySelectorAll('.sync-new-check:checked').length;
+  const changedActive = document.querySelectorAll('.sync-changed-radio:checked:not([value="skip"])').length;
+  const pushChecked = document.querySelectorAll('.sync-push-check:checked').length;
+  const total = newChecked + changedActive + pushChecked;
+  const btn = document.getElementById('sync-apply-btn');
+  btn.disabled = total === 0;
+  btn.textContent = total ? `Apply Sync (${total})` : 'Apply Sync';
+}
+
+function buildSyncPayload() {
+  const toSleeveNotes = [];
+  const toDiscogs = [];
+
+  document.querySelectorAll('.sync-new-check:checked').forEach(el => {
+    const r = diffData.new[+el.dataset.idx];
+    toSleeveNotes.push({ action: 'create', prospective: r });
+  });
+
+  document.querySelectorAll('.sync-changed-radio:checked').forEach(el => {
+    if (el.value === 'skip') return;
+    const r = diffData.changed[+el.dataset.idx];
+    if (el.value === 'to_sleevenotes') {
+      const prospective = {};
+      Object.entries(r.changes).forEach(([col, { to }]) => {
+        prospective[col] = (to === null || to === undefined || String(to).trim() === '') ? null : to;
+      });
+      toSleeveNotes.push({ action: 'update', record_id: r.record_id, prospective });
+    } else {
+      const changedCols = new Set(Object.keys(r.changes));
+      toDiscogs.push({
+        action: 'update',
+        record_id: r.record_id,
+        instance_id: r.prospective.instance_id || r.current.instance_id || null,
+        discogs_id: r.current.discogs_id,
+        folder_id: r.prospective.folder_id || r.current.folder_id || 1,
+        updates: buildFieldUpdates(r.current, changedCols),
+      });
+    }
+  });
+
+  const pushable = diffData.db_only.filter(r => r.discogs_id);
+  document.querySelectorAll('.sync-push-check:checked').forEach(el => {
+    const r = pushable[+el.dataset.idx];
+    toDiscogs.push({
+      action: 'create',
+      record_id: r.id,
+      discogs_id: r.discogs_id,
+      folder_id: r.folder_id || 1,
+      updates: buildFieldUpdates(r),
+    });
+  });
+
+  return { to_sleevenotes: toSleeveNotes, to_discogs: toDiscogs };
+}
+
+async function applySync() {
+  const payload = buildSyncPayload();
+  const btn = document.getElementById('sync-apply-btn');
+  btn.disabled = true;
+  btn.textContent = 'Applying…';
+  try {
+    const resp = await fetch('/api/collection/sync', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload),
+    });
+    if (!resp.ok) throw new Error((await resp.json()).detail || resp.status);
+    const result = await resp.json();
+    closeModal('modal-discogs-sync');
+    const parts = [];
+    if (result.sn_created) parts.push(`${result.sn_created} added to SleeveNotes`);
+    if (result.sn_updated) parts.push(`${result.sn_updated} updated in SleeveNotes`);
+    if (result.discogs_created) parts.push(`${result.discogs_created} added to Discogs`);
+    if (result.discogs_updated) parts.push(`${result.discogs_updated} updated in Discogs`);
+    if (result.sn_refreshing) parts.push(`fetching covers for ${result.sn_refreshing} records…`);
+    toast(parts.length ? `Sync complete: ${parts.join(', ')}` : 'Sync complete', 'success');
+    const syncedSnIds = new Set(
+      payload.to_sleevenotes.filter(i => i.action === 'update').map(i => i.record_id)
+    );
+    await loadRecords();
+    if (editingId && syncedSnIds.has(editingId)) openEdit(editingId);
+    if (result.sn_refreshing) startCoverPoll(result.sn_refreshing);
+  } catch(e) {
+    toast('Sync failed: ' + e.message, 'error');
+    updateSyncApplyBtn();
+  }
+}
+
 // ── Settings ───────────────────────────────────────────────────────────────
 function openSettings() {
   document.getElementById('clean-artists-toggle').checked = cleanArtists;
   document.getElementById('include-pp-toggle').checked = includePP;
-  document.getElementById('hide-obvious-formats-toggle').checked = hideObviousFormats;
+  document.getElementById('hide-format-tags-toggle').checked = hideObviousFormats;
+  document.getElementById('hidden-format-tags-input').value = [...hiddenFormatTags].join(', ');
+  document.getElementById('hidden-format-tags-input').disabled = !hideObviousFormats;
+  document.getElementById('hidden-format-tags-input').style.opacity = hideObviousFormats ? '1' : '0.4';
+  document.getElementById('settings-discogs-username').value = discogsUsername;
+  document.getElementById('settings-discogs-token').value = '';  // never pre-fill token
   document.getElementById('format-safety-toggle').checked = false;
   onFormatToggle();
+  document.getElementById('factory-reset-safety-toggle').checked = false;
+  onFactoryResetToggle();
   document.getElementById('clear-images-safety-toggle').checked = false;
   onClearImagesToggle();
   buildFetchRanges();
   document.getElementById('fetch-progress').classList.add('hidden');
+  // Reset mapping section then fetch (or prompt if no username yet)
+  document.getElementById('settings-mapping-section').style.display = 'none';
+  if (discogsUsername) {
+    document.getElementById('settings-mapping-loading').style.display = '';
+    document.getElementById('settings-mapping-loading').textContent = 'Loading…';
+    loadDiscogsFields();
+  } else {
+    document.getElementById('settings-mapping-loading').style.display = '';
+    document.getElementById('settings-mapping-loading').textContent = 'Enter a Discogs username above to configure field mapping.';
+  }
   openModal('modal-settings');
+}
+
+async function saveSettings() {
+  const newCleanArtists = document.getElementById('clean-artists-toggle').checked;
+  const newIncludePP = document.getElementById('include-pp-toggle').checked;
+  const newHideFormatTags = document.getElementById('hide-format-tags-toggle').checked;
+  const newHiddenTags = document.getElementById('hidden-format-tags-input').value;
+  const newUsername = document.getElementById('settings-discogs-username').value.trim();
+  const newToken = document.getElementById('settings-discogs-token').value.trim();
+
+  const newMappings = {};
+  document.querySelectorAll('#discogs-fields-rows select').forEach(sel => {
+    if (sel.value) newMappings[sel.value] = sel.dataset.dbCol;
+  });
+
+  const puts = [
+    ['clean_artists', String(newCleanArtists)],
+    ['include_pp', String(newIncludePP)],
+    ['hide_obvious_formats', String(newHideFormatTags)],
+    ['hidden_format_tags', newHiddenTags],
+    ['discogs_username', newUsername],
+    ['discogs_field_mappings', JSON.stringify(newMappings)],
+  ];
+  if (newToken) puts.push(['discogs_token', newToken]);
+
+  await Promise.all(puts.map(([key, value]) =>
+    fetch(`/api/settings/${key}`, {
+      method: 'PUT', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ value }),
+    })
+  ));
+
+  const usernameChanged = newUsername !== discogsUsername;
+  cleanArtists = newCleanArtists;
+  includePP = newIncludePP;
+  hideObviousFormats = newHideFormatTags;
+  hiddenFormatTags = new Set(newHiddenTags.split(',').map(t => t.trim()).filter(Boolean));
+  discogsUsername = newUsername;
+  discogsFieldMappings = newMappings;
+
+  toast('Settings saved');
+  renderView();
+  updateStats();
+  updateFormatFilterBar();
+
+  // Refresh field mapping in-place if username was just added or changed
+  document.getElementById('settings-mapping-section').style.display = 'none';
+  if (discogsUsername) {
+    document.getElementById('settings-mapping-loading').style.display = '';
+    document.getElementById('settings-mapping-loading').textContent = usernameChanged ? 'Loading…' : '';
+    loadDiscogsFields();
+  } else {
+    document.getElementById('settings-mapping-loading').style.display = '';
+    document.getElementById('settings-mapping-loading').textContent = 'Enter a Discogs username above to configure field mapping.';
+  }
 }
 
 function onCleanArtistsToggle() {
   cleanArtists = document.getElementById('clean-artists-toggle').checked;
-  fetch('/api/settings/clean_artists', {
-    method: 'PUT',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ value: String(cleanArtists) }),
-  });
   renderView();
 }
 
 function onIncludePPToggle() {
   includePP = document.getElementById('include-pp-toggle').checked;
-  fetch('/api/settings/include_pp', {
-    method: 'PUT',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ value: String(includePP) }),
-  });
   updateStats();
 }
 
-function onHideObviousFormatsToggle() {
-  hideObviousFormats = document.getElementById('hide-obvious-formats-toggle').checked;
-  fetch('/api/settings/hide_obvious_formats', {
-    method: 'PUT',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ value: String(hideObviousFormats) }),
-  });
+function onHideFormatTagsToggle() {
+  hideObviousFormats = document.getElementById('hide-format-tags-toggle').checked;
+  const input = document.getElementById('hidden-format-tags-input');
+  input.disabled = !hideObviousFormats;
+  input.style.opacity = hideObviousFormats ? '1' : '0.4';
+  updateFormatFilterBar();
+  renderView();
+}
+
+function onHiddenTagsChange() {
+  const val = document.getElementById('hidden-format-tags-input').value;
+  hiddenFormatTags = new Set(val.split(',').map(t => t.trim()).filter(Boolean));
   updateFormatFilterBar();
   renderView();
 }
@@ -2095,9 +2517,30 @@ function onFormatToggle() {
 }
 
 async function doFormatDb() {
-  if (!confirm('This will permanently delete every record in your collection. Are you sure?')) return;
+  if (!confirm('This will permanently delete every record in your collection. Settings will be preserved. Are you sure?')) return;
   try {
     const r = await fetch('/api/admin/format', { method: 'POST' });
+    if (!r.ok) throw new Error();
+    closeModal('modal-settings');
+    await loadRecords();
+    toast('All records deleted', 'success');
+  } catch {
+    toast('Delete failed', 'error');
+  }
+}
+
+function onFactoryResetToggle() {
+  const enabled = document.getElementById('factory-reset-safety-toggle').checked;
+  const btn = document.getElementById('factory-reset-btn');
+  btn.disabled = !enabled;
+  btn.style.opacity = enabled ? '1' : '0.4';
+  btn.style.cursor = enabled ? 'pointer' : 'not-allowed';
+}
+
+async function doFactoryReset() {
+  if (!confirm('This will permanently delete all records and reset all settings to defaults. Are you sure?')) return;
+  try {
+    const r = await fetch('/api/admin/factory-reset', { method: 'POST' });
     if (!r.ok) throw new Error();
     closeModal('modal-settings');
     await loadRecords();
@@ -2134,10 +2577,8 @@ function coverThumb(r) {
   return `<div class="cover-placeholder">♪</div>`;
 }
 
-function statusClass(s) {
-  if (s === 'In Collection') return 'badge-ic';
-  if (s === 'Returned') return 'badge-r';
-  return 'badge-p';
+function statusClass(_s) {
+  return 'badge-ic';
 }
 
 function discogsNum(id) { return String(id||'').replace(/^r/, ''); }
@@ -2169,7 +2610,7 @@ const COND_LABELS = {
 };
 function condLabel(c) {
   const s = (c || '').trim().toUpperCase();
-  return COND_LABELS[s] ? `${COND_LABELS[s]} (${c})` : (c || '—');
+  return COND_LABELS[s] ? `${COND_LABELS[s]} (${c})` : (c || 'Unknown');
 }
 
 function truncate(s, max) {
@@ -2179,7 +2620,7 @@ function truncate(s, max) {
 function formatTags(s, respectHide = true) {
   if (!s) return [];
   const tags = s.split(',').map(t => t.trim()).filter(Boolean);
-  return (respectHide && hideObviousFormats) ? tags.filter(t => !OBVIOUS_FORMATS.has(t)) : tags;
+  return (respectHide && hideObviousFormats && hiddenFormatTags.size) ? tags.filter(t => !hiddenFormatTags.has(t)) : tags;
 }
 
 function fmtTagsHtml(s) {


### PR DESCRIPTION
- Rate limiter: process-wide sliding-window broker (55 req/min) for all Discogs API calls; replaces scattered manual sleeps
- Collection sync: diff and apply changes between Discogs collection and SN; background refresh fetches covers/tracklists after import
- CSV import: partial sync (db_only cleared); SN_ prefix on export for round-trip support; syncSource flag controls modal behaviour
- Three-state is_new: NULL=unknown, 0=pre-owned, 1=new; records without a mapped field default to unknown rather than pre-owned
- compute_diff: None-safe string comparison; zero-default suppression for price/pp/valuation to avoid false positives
- Settings modal: save stays open with separate Close button; section order Display → Discogs → Data → Danger Zone
- Format tags: global on/off toggle + configurable hidden tags text input
- Danger Zone: Delete All Records + Format Database (factory reset)
- Stats bar: merged Total Entries/In Collection → Total Records
- Remove DISCOGS_TOKEN env var fallback; token set via Settings only
- Remove sleevenotes.env/.env.example and env_file from compose.yml