### PR TITLE
Fix Android adaptive icon (add maskable purpose)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,11 @@ S (Sealed) → M → NM → VG+ → VG → G+ → G → F → P
 - **Wishlist cover prefix:** Master release covers are stored as `m{master_id}_01.jpeg` to avoid filename collision with release images (`r{release_id}_...`).
 - **PWA:** `static/manifest.json`, `static/sw.js` (minimal — satisfies Chrome install requirement), `static/icon.svg`, `static/icon-192.png`, `static/icon-512.png`. Offline detection via `navigator.onLine` + `window online/offline` events toggles a `body.offline` CSS class and an amber banner. Write actions (Add Record, Sync, Import, Settings Save, Edit, Delete) are disabled offline. Wishlist always fetches all items (`show_fulfilled=true`) and filters client-side so the fulfilled toggle works offline without re-fetching.
 
+## Known Bugs
+
+### Offline banner doesn't trigger on mobile with 5G but no home server
+`navigator.onLine` returns `true` whenever the device has any internet connection, so the offline banner and read-only mode never activate when the user is away from home on mobile data. The fix requires active server reachability probing (see Offline wishlist adding feature request below for the full two-state design).
+
 ## Feature Requests
 
 ### Offline wishlist adding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ Two distinct offline states need separate detection and banners:
 Design notes:
 - Backend needs a lightweight `GET /api/health` endpoint
 - Server reachability probed every ~30s + on any failed API call
-- Wishlist search calls Discogs directly from the browser (unauthenticated API, 25 req/min — fine for personal use) bypassing the backend
+- Wishlist search calls Discogs directly from the browser (unauthenticated API, 25 req/min — fine for personal use) bypassing the backend. The Discogs token is never sent to the frontend, so anonymous mode is a deliberate fallback — do not cache the token client-side to increase the rate limit
 - Adds queued as `{master_id, notes, queued_at}` in IndexedDB; displayed in wishlist as pending placeholders (no cover/metadata yet)
 - On reconnect, queue flushed via `POST /api/wishlist` per item; 409 (already exists) swallowed silently
 - Background Sync API can flush queue even when app is closed (Android only — iOS does not support it)

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -21,6 +21,18 @@
       "src": "/icon.svg",
       "sizes": "any",
       "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `"purpose": "maskable"` entries for the 192px and 512px PNG icons in `manifest.json`
- Fixes Android showing the icon as a square shrunk inside its circular/squircle mask; the OS will now crop the icon to shape instead of letterboxing it
- Reuses existing PNG files — the cream background already fills the canvas, so no artwork changes needed

Closes #12

## Test plan
- [ ] Uninstall and reinstall the PWA on Android
- [ ] Confirm the home screen icon shows a cream circle with the vinyl, not a square inside a circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)