### PR TITLE
Document git branching workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ Runtime data (not in repo):
 /data/images/           # Cached Discogs cover images
 ```
 
+## Git Workflow
+
+Always create a feature branch before making any code or config changes. Never commit directly to `main`. Branch naming: `fix/<slug>` for bugs, `feat/<slug>` for features, `docs/<slug>` for documentation.
+
 ## Running Locally
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a **Git Workflow** section to CLAUDE.md requiring a feature branch before any code or config changes
- Establishes branch naming convention: `fix/`, `feat/`, `docs/`
- Prevents direct commits to `main`

## Test plan
- [ ] No functional changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)