### PR TITLE
Support versioned Docker image tags via GitHub releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
     paths-ignore:
       - 'CLAUDE.md'
       - '**.md'
@@ -27,9 +29,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/sidtheturtle/sleevenotes
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ghcr.io/sidtheturtle/sleevenotes:latest
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary

- On push to `main`: publishes `latest` as before
- On GitHub release tagged `vX.Y.Z`: publishes both the semver image tag (e.g. `1.2.3`) and updates `latest`

Users can pin their `compose.yml` to roll back:
```yaml
image: ghcr.io/sidtheturtle/sleevenotes:1.2.3
```

`paths-ignore` is preserved for branch pushes. Tag pushes always build regardless of changed files — if you're deliberately cutting a release you always want the image built.

## How to cut a release

GitHub → Releases → Draft new release → tag `v1.2.3` → Publish. CI handles the rest.

Version strategy: `v1.x.y` — minor bump for new features, patch bump for bug fixes.

## Test plan

- [ ] Push to `main` → only `latest` tag published (existing behaviour)
- [ ] Create a release tagged `v1.0.0` → both `1.0.0` and `latest` published to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)