### PR TITLE
Only update latest tag on versioned releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           images: ghcr.io/sidtheturtle/sleevenotes
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

Fixes the behaviour where `latest` was advancing ahead of the most recent versioned release on every main push.

**Before:** push to `main` → publishes `latest` (bleeding edge, ahead of last release)
**After:** push to `main` → publishes versioned semver tag only; `latest` only updates when a `vX.Y.Z` release tag is created

This means `latest` always reflects the last explicitly cut release, not unreleased work-in-progress on main.

## Test plan

- [ ] Merge to `main` → only a semver-tagged image published (no `latest` update)
- [ ] Create a release `vX.Y.Z` → both `X.Y.Z` and `latest` published

🤖 Generated with [Claude Code](https://claude.com/claude-code)