### PR TITLE
Only trigger Docker build on version tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,14 +2,8 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
-    paths-ignore:
-      - 'CLAUDE.md'
-      - '**.md'
-      - '.claude/**'
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary

Removes the `branches: main` trigger from the Docker workflow. Builds now only run on `vX.Y.Z` tag pushes, fixing the build failure introduced when `latest` was made release-only.

**Root cause:** with `latest` disabled on branch pushes, `metadata-action` generated zero tags on main push, causing `build-push-action` to error with "tag is needed when pushing to registry".

**Fix:** since main pushes have nothing to publish, remove the trigger entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)