### PR TITLE
Exclude .claude/settings.local.json from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+
+# Claude Code local config (contains personal paths/permissions)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore` so personal Claude Code config (permission rules, local paths) can never be accidentally committed
- The file is already gitignored by Claude Code's own tooling, but wasn't covered by the repo's `.gitignore` — this makes it explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)