### PR TITLE
Fix: preserve user-set cover image across refreshes and syncs

### DIFF
--- a/app.py
+++ b/app.py
@@ -629,7 +629,7 @@ async def _refresh_from_discogs(client, hdrs: dict, record_id: int, discogs_id: 
             return
         data = release_resp.json()
         downloaded = await download_all_images(data.get("images", []), f"r{rid}", hdrs)
-        cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=False)
+        cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=True)
         upsert_tracklist(f"r{rid}", data.get("tracklist", []))
         stats = stats_resp.json() if stats_resp.status_code == 200 else {}
         lp = stats.get("lowest_price") or {}
@@ -777,7 +777,7 @@ async def fetch_discogs(release_id: str):
         raise HTTPException(status_code=release_resp.status_code, detail="Discogs fetch failed")
     data = release_resp.json()
     downloaded = await download_all_images(data.get("images", []), f"r{rid}", hdrs)
-    cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=False)
+    cover_file = upsert_images(f"r{rid}", downloaded, preserve_cover=True)
     upsert_tracklist(f"r{rid}", data.get("tracklist", []))
     labels = data.get("labels", [])
     label = labels[0].get("name", "") if labels else ""


### PR DESCRIPTION
## Summary
- Custom cover images (non-default) were being reset to image 1 after a collection sync or Discogs metadata fetch in the add/edit form
- Two `upsert_images` call sites had `preserve_cover=False` when they should respect any existing user choice
- `preserve_cover=True` is safe for new records — `upsert_images` falls back to image 1 when no cover has been set yet

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)