### PR TITLE
feat: nav restructure — Collection/Wishlist top-level, Table/Tile for both (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ docker exec sleevenotes rm /data/sleevenotes.db
 |---|---|---|
 | `clean_artists` | `true` | Strip Discogs disambiguation numbers from display |
 | `include_pp` | `false` | Include P&P in Collection Cost KPI |
+| `show_valuations` | `true` | Show Collection Value KPI and per-record valuation column |
 | `hide_obvious_formats` | `true` | Global on/off for format tag hiding |
 | `hidden_format_tags` | `Album, LP, Stereo, Vinyl` | Comma-separated tags to hide from filter bar |
 | `discogs_username` | `` | Required for collection sync |
@@ -202,12 +203,13 @@ Everything lives in one file. No framework, no build step.
 ### Global state
 ```js
 records           // array — full dataset from API
-currentView       // 'table' | 'tile' | 'wishlist'
+currentSection    // 'collection' | 'wishlist'
+currentView       // 'table' | 'tile'
 editingId         // null or record id
 fetchedMeta       // Discogs preview data during add/edit
 sortCol           // active sort column key or null
 sortDir           // 'asc' | 'desc' | null
-showValuations    // bool — toggle collection value display
+showValuations    // bool — show Collection Value KPI and valuation column (DB-backed)
 showTags          // bool — toggle format filter bar visibility
 filterFormat      // active format tag string, or null
 diffData          // last sync diff payload
@@ -220,10 +222,10 @@ serverReachable   // bool — false when internet present but server unreachable
 _reachabilityPollTimer // setTimeout handle for backoff reachability polling
 ```
 
-Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within Collection. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. Only `'table'`/`'tile'` are saved to localStorage — app always opens to collection.
+Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within **both** sections. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. Only `'table'`/`'tile'` are saved to localStorage — app always opens to collection.
 
 ### localStorage persistence
-All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view` (table/tile only — wishlist never persisted as startup view), `showValuations`, `showTags`, `groupByArtist`, `showFulfilled`.
+All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view` (table/tile only — wishlist never persisted as startup view), `showTags`, `groupByArtist`, `showFulfilled`. `showValuations` is DB-backed via the `settings` table, not localStorage.
 
 ### Key functions
 
@@ -250,16 +252,17 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 | `importCsv(input)` | POST CSV → sets `syncSource='csv'` → opens sync modal |
 | `openSettings()` | Open settings modal; reloads field mapping in-place |
 | `saveSettings()` | Persist settings; stays open; refreshes field mapping if username changed |
-| `loadWishlist()` | Fetch `/api/wishlist`, update `wishlistItems`, update stats; calls `renderWishlist()` only if `currentView === 'wishlist'` |
-| `renderWishlist()` | Build sortable wishlist table (cover, Artist, Title, Year, Added, Notes); no inline search filtering |
+| `loadWishlist()` | Fetch `/api/wishlist`, update `wishlistItems`, update stats; calls `renderWishlist()` only if `currentSection === 'wishlist'` |
+| `renderWishlist()` | Delegates to `renderWishlistTiles()` when `currentView === 'tile'`, otherwise builds sortable table (cover, Artist, Title, Year, Added, Notes); no inline search filtering |
+| `renderWishlistTiles()` | Build wishlist cover art grid sorted artist → year; clicking a tile opens detail modal directly |
 | `openWishlistSearchModal(prefill)` | Open master release search modal; auto-searches if prefill provided |
 | `doWishlistSearch()` | POST to `/api/wishlist/search`, sort by year desc, render results with Add/On wishlist/Fulfilled state |
 | `addToWishlist(masterId)` | POST to `/api/wishlist`, close modal, clear search bar, reload wishlist |
 | `fulfillWishlistItem(id)` | PUT fulfilled=true, reload wishlist |
 | `deleteWishlistItem(id)` | DELETE item, reload wishlist |
 | `openWishlistDetail(id)` | Open detail modal: cover, metadata (year/genres/styles/lowest price), notes textarea, Mark Fulfilled + Delete + Save buttons |
-| `setSection(section)` | Top-level nav: `'collection'` restores last table/tile, `'wishlist'` switches to wishlist |
-| `applyToolbarSwitches(v)` | Show/hide collection view-toggle and switches vs wishlist switches; update search placeholder |
+| `setSection(section)` | Top-level nav: sets `currentSection`, updates nav buttons, calls `applyToolbarSwitches`, loads/renders appropriate view |
+| `applyToolbarSwitches(s)` | Show/hide collection vs wishlist switches; `collection-view-toggle` always visible (both sections support Table/Tile); update search placeholder |
 | `apiFetch(url, opts)` | Wrapper around `fetch` for all `/api/` calls — catches `TypeError` and triggers `probeHealth()` if online |
 | `checkHealth()` | `fetch('/api/health')` with 5s timeout; returns bool — uses plain `fetch`, not `apiFetch`, to avoid recursion |
 | `probeHealth()` | Calls `checkHealth()` and passes result to `setServerReachable()` |
@@ -268,12 +271,14 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 | `updateOnlineState()` | Sets `body.offline` class and banner for both offline states; disables write actions |
 
 ### Views
-- **Table:** Clickable column headers cycle asc/desc/clear. "Group by artist" toggle overrides column sort with artist A-Z + year.
-- **Tiles:** Always sorted artist A-Z → year. Clicking a tile opens detail modal.
-- **Wishlist:** Sortable table (artist, title, year, added date). No inline search filtering — the search bar is a CTA that opens the master release search modal on Enter. Switching views clears the search bar. Format filter bar hidden. Toolbar shows "Show fulfilled" toggle only.
+- **Table (Collection):** Clickable column headers cycle asc/desc/clear. "Group by artist" toggle overrides column sort with artist A-Z + year.
+- **Tiles (Collection):** Always sorted artist A-Z → year. First tap shows overlay; second tap (or overlay button) opens detail modal.
+- **Table (Wishlist):** Sortable table (artist, title, year, added date). No inline search filtering — the search bar is a CTA that opens the master release search modal on Enter.
+- **Tiles (Wishlist):** Cover art grid sorted artist → year. Single click opens detail modal directly (no two-tap selection model).
+- Both wishlist views: Format filter bar hidden. Toolbar shows "Show fulfilled" toggle only. Switching sections clears the search bar.
 
 ### Toolbar
-Always visible (no collapse toggle). Two rows: a nav row (`[Collection] [Wishlist]`) that spans full width, followed by an options row (Table/Tile sub-views, search, toggles) that changes based on the active section.
+Always visible (no collapse toggle). Single nav row: `[Collection] [Wishlist]` pair, separator, `[Table] [Tiles]` pair (always shown for both sections), then search and context-sensitive toggles.
 
 ### Modals
 - `modal-detail` — read-only record detail (tile click)
@@ -284,7 +289,7 @@ Always visible (no collapse toggle). Two rows: a nav row (`[Collection] [Wishlis
 - `modal-wishlist-detail` — Wishlist item detail: cover, metadata, notes editing, Mark Fulfilled, Delete
 
 ### Settings modal sections (top to bottom)
-1. **Display** — Clean artists, Include P&P, Hide format tags (toggle + tag list)
+1. **Display** — Clean artists, Include P&P, Show Valuations, Hide format tags (toggle + tag list). **All display toggles are staged — state only applies on Save, not on toggle.**
 2. **Discogs** — Username, Token, Refresh Metadata, Field Mapping, Sync Collection
 3. **Data** — Import from CSV, Export to CSV
 4. **Danger Zone** — Delete All Records (records only), Format Database (factory reset), Clear Image Cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,8 +220,10 @@ serverReachable   // bool — false when internet present but server unreachable
 _reachabilityPollTimer // setTimeout handle for backoff reachability polling
 ```
 
+Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within Collection. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. Only `'table'`/`'tile'` are saved to localStorage — app always opens to collection.
+
 ### localStorage persistence
-All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view`, `showValuations`, `showTags`, `groupByArtist`, `toolbarExpanded`, `showFulfilled`.
+All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view` (table/tile only — wishlist never persisted as startup view), `showValuations`, `showTags`, `groupByArtist`, `showFulfilled`.
 
 ### Key functions
 
@@ -256,7 +258,8 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 | `fulfillWishlistItem(id)` | PUT fulfilled=true, reload wishlist |
 | `deleteWishlistItem(id)` | DELETE item, reload wishlist |
 | `openWishlistDetail(id)` | Open detail modal: cover, metadata (year/genres/styles/lowest price), notes textarea, Mark Fulfilled + Delete + Save buttons |
-| `applyToolbarSwitches(v)` | Show/hide collection vs wishlist toolbar sections; update search placeholder |
+| `setSection(section)` | Top-level nav: `'collection'` restores last table/tile, `'wishlist'` switches to wishlist |
+| `applyToolbarSwitches(v)` | Show/hide collection view-toggle and switches vs wishlist switches; update search placeholder |
 | `apiFetch(url, opts)` | Wrapper around `fetch` for all `/api/` calls — catches `TypeError` and triggers `probeHealth()` if online |
 | `checkHealth()` | `fetch('/api/health')` with 5s timeout; returns bool — uses plain `fetch`, not `apiFetch`, to avoid recursion |
 | `probeHealth()` | Calls `checkHealth()` and passes result to `setServerReachable()` |
@@ -270,7 +273,7 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 - **Wishlist:** Sortable table (artist, title, year, added date). No inline search filtering — the search bar is a CTA that opens the master release search modal on Enter. Switching views clears the search bar. Format filter bar hidden. Toolbar shows "Show fulfilled" toggle only.
 
 ### Toolbar
-Collapsible via the "Options ▾" button in the header. Collapsed by default on mobile (`< 768px`), expanded on desktop. State persisted to localStorage.
+Always visible (no collapse toggle). Two rows: a nav row (`[Collection] [Wishlist]`) that spans full width, followed by an options row (Table/Tile sub-views, search, toggles) that changes based on the active section.
 
 ### Modals
 - `modal-detail` — read-only record detail (tile click)

--- a/app.py
+++ b/app.py
@@ -95,6 +95,7 @@ SETTINGS_DEFAULTS: dict[str, str] = {
     "include_pp":           "false",
     "hide_obvious_formats": "true",
     "hidden_format_tags":   "Album, LP, Stereo, Vinyl",
+    "show_valuations":      "true",
     "discogs_username":     "",
     "discogs_token":        "",
     "discogs_field_mappings": "{}",

--- a/static/index.html
+++ b/static/index.html
@@ -930,16 +930,17 @@
 
 <div class="toolbar" id="toolbar">
   <div class="toolbar-nav">
-    <button class="btn btn-ghost active" id="btn-collection" onclick="setSection('collection')">⊙ Collection</button>
-    <button class="btn btn-ghost" id="btn-wishlist-nav" onclick="setSection('wishlist')">♡ Wishlist</button>
-  </div>
-
-  <div id="collection-view-toggle" style="display:contents">
     <div class="view-toggle">
-      <button class="btn btn-ghost active" id="btn-table" onclick="setView('table')">▤ Table</button>
-      <button class="btn btn-ghost" id="btn-tile" onclick="setView('tile')">⊞ Tiles</button>
+      <button class="btn btn-ghost active" id="btn-collection" onclick="setSection('collection')">⊙ Collection</button>
+      <button class="btn btn-ghost" id="btn-wishlist-nav" onclick="setSection('wishlist')">♡ Wishlist</button>
     </div>
-    <div class="toolbar-sep"></div>
+    <div id="collection-view-toggle" style="display:contents">
+      <div class="toolbar-sep"></div>
+      <div class="view-toggle">
+        <button class="btn btn-ghost active" id="btn-table" onclick="setView('table')">▤ Table</button>
+        <button class="btn btn-ghost" id="btn-tile" onclick="setView('tile')">⊞ Tiles</button>
+      </div>
+    </div>
   </div>
 
   <div class="search-wrap">
@@ -957,15 +958,6 @@
         <div class="toggle-thumb"></div>
       </label>
       <span style="font-size:12px;color:var(--ink-light)">Group by artist</span>
-    </label>
-
-    <label class="toggle-row" style="cursor:pointer">
-      <label class="toggle">
-        <input type="checkbox" id="show-valuations" onchange="onShowValuationsToggle()">
-        <div class="toggle-track"></div>
-        <div class="toggle-thumb"></div>
-      </label>
-      <span style="font-size:12px;color:var(--ink-light)">Show valuations</span>
     </label>
 
     <label class="toggle-row" style="cursor:pointer">
@@ -1200,6 +1192,17 @@
             <div class="toggle-thumb"></div>
           </label>
         </div>
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
+          <div>
+            <div style="font-size:13px;font-weight:500;color:var(--ink)">Show valuations</div>
+            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Show the Collection Value KPI and per-record Discogs marketplace valuations.</div>
+          </div>
+          <label class="toggle" style="flex-shrink:0" title="Show valuations">
+            <input type="checkbox" id="show-valuations" onchange="onShowValuationsToggle()">
+            <div class="toggle-track"></div>
+            <div class="toggle-thumb"></div>
+          </label>
+        </div>
         <div style="display:flex;flex-direction:column;gap:0.4rem;">
           <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
             <div>
@@ -1393,6 +1396,7 @@
 <script>
 // ── State ──────────────────────────────────────────────────────────────────
 let records = [];
+let currentSection = 'collection';
 let currentView = 'table';
 let editingId = null;
 let fetchedMeta = {};
@@ -1421,16 +1425,12 @@ function lsSet(key, val) {
 }
 
 function restoreLocalState() {
-  const stored = lsGet('view', 'table');
-  currentView = stored === 'wishlist' ? 'table' : stored;
+  currentView = lsGet('view', 'table');
   document.getElementById('btn-table').classList.toggle('active', currentView === 'table');
   document.getElementById('btn-tile').classList.toggle('active', currentView === 'tile');
   document.getElementById('btn-collection').classList.add('active');
   document.getElementById('btn-wishlist-nav').classList.remove('active');
-  applyToolbarSwitches(currentView);
-
-  showValuations = lsGet('showValuations', false);
-  document.getElementById('show-valuations').checked = showValuations;
+  applyToolbarSwitches('collection');
 
   showTags = lsGet('showTags', false);
   document.getElementById('show-tags').checked = showTags;
@@ -1470,7 +1470,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (e.target === e.currentTarget) closeModal('modal-wishlist-search');
   });
   document.getElementById('search').addEventListener('keydown', e => {
-    if (e.key === 'Enter' && currentView === 'wishlist') {
+    if (e.key === 'Enter' && currentSection === 'wishlist') {
       openWishlistSearchModal(document.getElementById('search').value.trim());
     }
   });
@@ -1498,6 +1498,10 @@ async function loadSettings() {
       if (s.hide_obvious_formats !== undefined) hideObviousFormats = s.hide_obvious_formats === 'true';
       if (s.hidden_format_tags !== undefined)
         hiddenFormatTags = new Set(s.hidden_format_tags.split(',').map(t => t.trim()).filter(Boolean));
+      if (s.show_valuations !== undefined) {
+        showValuations = s.show_valuations === 'true';
+        document.getElementById('show-valuations').checked = showValuations;
+      }
       discogsUsername = s.discogs_username || '';
       try { discogsFieldMappings = JSON.parse(s.discogs_field_mappings || '{}'); } catch { discogsFieldMappings = {}; }
       // token is not surfaced to JS state — it stays in the DB and is read server-side
@@ -1547,17 +1551,15 @@ function updateStats() {
   const cost = records.reduce((s,r) => s + (r.price||0) + (includePP ? (r.pp||0) : 0), 0);
   const valuation = records.reduce((s,r) => s + (r.valuation||0), 0);
   document.getElementById('s-total').textContent = records.length;
-  document.getElementById('s-cost').textContent = showValuations ? '£' + cost.toFixed(2) : '—';
-  document.getElementById('s-valuation').textContent = showValuations && valuation ? '£' + valuation.toFixed(2) : '—';
+  document.getElementById('s-cost').closest('.stat-item').style.display = showValuations ? '' : 'none';
+  document.getElementById('s-cost').textContent = '£' + cost.toFixed(2);
+  document.getElementById('s-valuation').closest('.stat-item').style.display = showValuations ? '' : 'none';
+  document.getElementById('s-valuation').textContent = valuation ? '£' + valuation.toFixed(2) : '—';
   const wCount = wishlistItems.filter(w => !w.fulfilled).length;
   document.getElementById('s-wishlist').textContent = wCount || '—';
 }
 
-function onShowValuationsToggle() {
-  showValuations = document.getElementById('show-valuations').checked;
-  lsSet('showValuations', showValuations);
-  updateStats();
-}
+function onShowValuationsToggle() {}
 
 // ── Filtering & sorting ────────────────────────────────────────────────────
 function getFiltered() {
@@ -1626,26 +1628,29 @@ function setView(v) {
   document.getElementById('search').value = '';
   document.getElementById('btn-table').classList.toggle('active', v === 'table');
   document.getElementById('btn-tile').classList.toggle('active', v === 'tile');
-  document.getElementById('btn-collection').classList.toggle('active', v !== 'wishlist');
-  document.getElementById('btn-wishlist-nav').classList.toggle('active', v === 'wishlist');
-  applyToolbarSwitches(v);
+  lsSet('view', v);
+  applyToolbarSwitches(currentSection);
   updateFormatFilterBar();
-  if (v !== 'wishlist') lsSet('view', v);
-  if (v === 'wishlist') loadWishlist();
-  else renderView();
+  renderView();
 }
 
 function setSection(section) {
-  if (section === 'wishlist') setView('wishlist');
-  else setView(lsGet('view', 'table'));
+  currentSection = section;
+  selectedTileId = null;
+  document.getElementById('search').value = '';
+  document.getElementById('btn-collection').classList.toggle('active', section === 'collection');
+  document.getElementById('btn-wishlist-nav').classList.toggle('active', section === 'wishlist');
+  applyToolbarSwitches(section);
+  updateFormatFilterBar();
+  if (section === 'wishlist') loadWishlist();
+  else renderView();
 }
 
-function applyToolbarSwitches(v) {
-  const isWishlist = v === 'wishlist';
-  document.getElementById('collection-view-toggle').style.display = isWishlist ? 'none' : 'contents';
+function applyToolbarSwitches(s) {
+  const isWishlist = s === 'wishlist';
   document.getElementById('collection-switches').style.display = isWishlist ? 'none' : 'contents';
   document.getElementById('wishlist-switches').style.display = isWishlist ? 'contents' : 'none';
-  document.getElementById('group-by-wrapper').style.display = v === 'table' ? '' : 'none';
+  document.getElementById('group-by-wrapper').style.display = (!isWishlist && currentView === 'table') ? '' : 'none';
   document.getElementById('search').placeholder = isWishlist
     ? 'Search for a master release…'
     : 'Search artist, title, label…';
@@ -1664,9 +1669,9 @@ function onGroupByArtistToggle() {
 }
 
 function renderView() {
-  if (currentView === 'table') renderTable();
-  else if (currentView === 'tile') renderTiles();
-  else if (currentView === 'wishlist') renderWishlist();
+  if (currentSection === 'wishlist') renderWishlist();
+  else if (currentView === 'table') renderTable();
+  else renderTiles();
 }
 
 // ── Table view ─────────────────────────────────────────────────────────────
@@ -2502,6 +2507,7 @@ async function applySync() {
 function openSettings() {
   document.getElementById('clean-artists-toggle').checked = cleanArtists;
   document.getElementById('include-pp-toggle').checked = includePP;
+  document.getElementById('show-valuations').checked = showValuations;
   document.getElementById('hide-format-tags-toggle').checked = hideObviousFormats;
   document.getElementById('hidden-format-tags-input').value = [...hiddenFormatTags].join(', ');
   document.getElementById('hidden-format-tags-input').disabled = !hideObviousFormats;
@@ -2542,9 +2548,11 @@ async function saveSettings() {
     if (sel.value) newMappings[sel.value] = sel.dataset.dbCol;
   });
 
+  const newShowValuations = document.getElementById('show-valuations').checked;
   const puts = [
     ['clean_artists', String(newCleanArtists)],
     ['include_pp', String(newIncludePP)],
+    ['show_valuations', String(newShowValuations)],
     ['hide_obvious_formats', String(newHideFormatTags)],
     ['hidden_format_tags', newHiddenTags],
     ['discogs_username', newUsername],
@@ -2562,6 +2570,7 @@ async function saveSettings() {
   const usernameChanged = newUsername !== discogsUsername;
   cleanArtists = newCleanArtists;
   includePP = newIncludePP;
+  showValuations = newShowValuations;
   hideObviousFormats = newHideFormatTags;
   hiddenFormatTags = new Set(newHiddenTags.split(',').map(t => t.trim()).filter(Boolean));
   discogsUsername = newUsername;
@@ -2584,31 +2593,18 @@ async function saveSettings() {
   }
 }
 
-function onCleanArtistsToggle() {
-  cleanArtists = document.getElementById('clean-artists-toggle').checked;
-  renderView();
-}
+function onCleanArtistsToggle() {}
 
-function onIncludePPToggle() {
-  includePP = document.getElementById('include-pp-toggle').checked;
-  updateStats();
-}
+function onIncludePPToggle() {}
 
 function onHideFormatTagsToggle() {
-  hideObviousFormats = document.getElementById('hide-format-tags-toggle').checked;
+  const val = document.getElementById('hide-format-tags-toggle').checked;
   const input = document.getElementById('hidden-format-tags-input');
-  input.disabled = !hideObviousFormats;
-  input.style.opacity = hideObviousFormats ? '1' : '0.4';
-  updateFormatFilterBar();
-  renderView();
+  input.disabled = !val;
+  input.style.opacity = val ? '1' : '0.4';
 }
 
-function onHiddenTagsChange() {
-  const val = document.getElementById('hidden-format-tags-input').value;
-  hiddenFormatTags = new Set(val.split(',').map(t => t.trim()).filter(Boolean));
-  updateFormatFilterBar();
-  renderView();
-}
+function onHiddenTagsChange() {}
 
 function buildFetchRanges() {
   const container = document.getElementById('fetch-range-btns');
@@ -2720,7 +2716,7 @@ async function doClearImages() {
 
 async function loadWishlist() {
   if (!navigator.onLine || !serverReachable) {
-    if (currentView === 'wishlist') renderWishlist();
+    if (currentSection === 'wishlist') renderWishlist();
     updateStats();
     return;
   }
@@ -2730,13 +2726,41 @@ async function loadWishlist() {
     wishlistItems = await r.json();
   } catch {
     wishlistItems = [];
-    if (currentView === 'wishlist') toast('Failed to load wishlist', 'error');
+    if (currentSection === 'wishlist') toast('Failed to load wishlist', 'error');
   }
-  if (currentView === 'wishlist') renderWishlist();
+  if (currentSection === 'wishlist') renderWishlist();
   updateStats();
 }
 
+function renderWishlistTiles() {
+  const el = document.getElementById('main-content');
+  let items = showFulfilled ? wishlistItems : wishlistItems.filter(w => !w.fulfilled);
+  items = [...items].sort((a, b) => cmp(a.artist, b.artist) || cmpN(a.year, b.year));
+
+  if (!items.length) {
+    el.innerHTML = `<div class="empty">
+      <div class="empty-icon">♡</div>
+      <div class="empty-text">${wishlistItems.length ? 'No matching items' : 'Your wishlist is empty'}</div>
+      <div class="empty-sub">${wishlistItems.length ? 'Try adjusting your search' : 'Type a master release above and press Enter to search'}</div>
+    </div>`;
+    return;
+  }
+
+  el.innerHTML = `<div class="tile-grid">${items.map(w => `
+    <div class="tile" onclick="openWishlistDetail(${w.id})">
+      ${w.cover_file
+        ? `<img class="tile-img" src="/images/${esc(w.cover_file)}" alt="${esc(w.artist)} - ${esc(w.title)}" loading="lazy">`
+        : `<div class="tile-placeholder">♡</div>`}
+      <div class="tile-overlay">
+        <div class="tile-overlay-artist">${esc(w.artist)}</div>
+        <div class="tile-overlay-title">${esc(w.title)}</div>
+        ${w.year ? `<div style="font-size:11px;color:var(--cream);opacity:0.8;font-family:var(--font-mono);margin-top:0.15rem">${w.year}</div>` : ''}
+      </div>
+    </div>`).join('')}</div>`;
+}
+
 function renderWishlist() {
+  if (currentView === 'tile') { renderWishlistTiles(); return; }
   const el = document.getElementById('main-content');
   let items = showFulfilled ? wishlistItems : wishlistItems.filter(w => !w.fulfilled);
 
@@ -2883,7 +2907,7 @@ async function deleteWishlistItem(id) {
 function onShowFulfilledToggle() {
   showFulfilled = document.getElementById('show-fulfilled').checked;
   lsSet('showFulfilled', showFulfilled);
-  if (currentView === 'wishlist') renderWishlist();
+  if (currentSection === 'wishlist') renderWishlist();
 }
 
 function openWishlistDetail(id) {
@@ -3035,7 +3059,7 @@ function fmtTagsCell(s) {
 function updateFormatFilterBar() {
   const bar = document.getElementById('format-filter-bar');
   const allTags = [...new Set(records.flatMap(r => formatTags(r.format)))].sort();
-  if (currentView === 'wishlist' || !allTags.length || !showTags) { bar.style.display = 'none'; return; }
+  if (currentSection === 'wishlist' || !allTags.length || !showTags) { bar.style.display = 'none'; return; }
   bar.style.display = 'flex';
   bar.innerHTML = allTags.map(t =>
     `<span class="fmt-tag-filter${filterFormat === t ? ' active' : ''}" data-tag="${esc(t)}">${esc(t)}</span>`

--- a/static/index.html
+++ b/static/index.html
@@ -140,7 +140,14 @@
     border-bottom: 1px solid var(--border);
     flex-wrap: wrap;
   }
-  .toolbar.collapsed { display: none; }
+  .toolbar-nav {
+    flex: 1 1 100%;
+    display: flex;
+    gap: 0.25rem;
+    padding-bottom: 0.625rem;
+    border-bottom: 1px solid var(--border);
+    order: -1;
+  }
 
   .search-wrap {
     position: relative;
@@ -884,7 +891,7 @@
     .stats-bar { padding: 0.5rem 1rem; gap: 0.75rem; flex-wrap: wrap; }
     .stat-label { font-size: 9px; }
     .toolbar { padding: 0.75rem 1rem; gap: 0.5rem; }
-    .search-wrap { flex: 1 1 100%; order: -1; }
+    .search-wrap { flex: 1 1 100%; }
     main { padding: 1rem; }
     .form-grid { grid-template-columns: 1fr; }
     .detail-layout { grid-template-columns: 1fr; }
@@ -907,7 +914,6 @@
     SleeveNotes
   </div>
   <div class="header-actions">
-    <button class="btn btn-ghost btn-sm" id="toolbar-toggle-btn" onclick="toggleToolbar()"><span id="toolbar-toggle-icon">▾</span> Options</button>
     <button id="btn-add-record" class="btn btn-primary btn-sm" onclick="openAdd()">+ Add Record</button>
     <button id="btn-settings" class="btn btn-ghost btn-icon" onclick="openSettings()" title="Settings" style="color:var(--groove)">⚙</button>
   </div>
@@ -923,13 +929,18 @@
 </div>
 
 <div class="toolbar" id="toolbar">
-  <div class="view-toggle">
-    <button class="btn btn-ghost active" id="btn-table" onclick="setView('table')">▤ Table</button>
-    <button class="btn btn-ghost" id="btn-tile" onclick="setView('tile')">⊞ Tiles</button>
-    <button class="btn btn-ghost" id="btn-wishlist" onclick="setView('wishlist')">♡ Wishlist</button>
+  <div class="toolbar-nav">
+    <button class="btn btn-ghost active" id="btn-collection" onclick="setSection('collection')">⊙ Collection</button>
+    <button class="btn btn-ghost" id="btn-wishlist-nav" onclick="setSection('wishlist')">♡ Wishlist</button>
   </div>
 
-  <div class="toolbar-sep"></div>
+  <div id="collection-view-toggle" style="display:contents">
+    <div class="view-toggle">
+      <button class="btn btn-ghost active" id="btn-table" onclick="setView('table')">▤ Table</button>
+      <button class="btn btn-ghost" id="btn-tile" onclick="setView('tile')">⊞ Tiles</button>
+    </div>
+    <div class="toolbar-sep"></div>
+  </div>
 
   <div class="search-wrap">
     <span class="search-icon">⌕</span>
@@ -1410,10 +1421,12 @@ function lsSet(key, val) {
 }
 
 function restoreLocalState() {
-  currentView = lsGet('view', 'table');
+  const stored = lsGet('view', 'table');
+  currentView = stored === 'wishlist' ? 'table' : stored;
   document.getElementById('btn-table').classList.toggle('active', currentView === 'table');
   document.getElementById('btn-tile').classList.toggle('active', currentView === 'tile');
-  document.getElementById('btn-wishlist').classList.toggle('active', currentView === 'wishlist');
+  document.getElementById('btn-collection').classList.add('active');
+  document.getElementById('btn-wishlist-nav').classList.remove('active');
   applyToolbarSwitches(currentView);
 
   showValuations = lsGet('showValuations', false);
@@ -1428,9 +1441,6 @@ function restoreLocalState() {
   const groupByArtist = lsGet('groupByArtist', false);
   document.getElementById('group-by-artist').checked = groupByArtist;
 
-  const defaultExpanded = window.innerWidth >= 768;
-  const toolbarExpanded = lsGet('toolbarExpanded', defaultExpanded);
-  applyToolbarState(toolbarExpanded);
 }
 
 // ── Init ───────────────────────────────────────────────────────────────────
@@ -1616,33 +1626,29 @@ function setView(v) {
   document.getElementById('search').value = '';
   document.getElementById('btn-table').classList.toggle('active', v === 'table');
   document.getElementById('btn-tile').classList.toggle('active', v === 'tile');
-  document.getElementById('btn-wishlist').classList.toggle('active', v === 'wishlist');
+  document.getElementById('btn-collection').classList.toggle('active', v !== 'wishlist');
+  document.getElementById('btn-wishlist-nav').classList.toggle('active', v === 'wishlist');
   applyToolbarSwitches(v);
   updateFormatFilterBar();
-  lsSet('view', v);
+  if (v !== 'wishlist') lsSet('view', v);
   if (v === 'wishlist') loadWishlist();
   else renderView();
 }
 
+function setSection(section) {
+  if (section === 'wishlist') setView('wishlist');
+  else setView(lsGet('view', 'table'));
+}
+
 function applyToolbarSwitches(v) {
   const isWishlist = v === 'wishlist';
+  document.getElementById('collection-view-toggle').style.display = isWishlist ? 'none' : 'contents';
   document.getElementById('collection-switches').style.display = isWishlist ? 'none' : 'contents';
   document.getElementById('wishlist-switches').style.display = isWishlist ? 'contents' : 'none';
   document.getElementById('group-by-wrapper').style.display = v === 'table' ? '' : 'none';
   document.getElementById('search').placeholder = isWishlist
     ? 'Search for a master release…'
     : 'Search artist, title, label…';
-}
-
-function applyToolbarState(expanded) {
-  document.getElementById('toolbar').classList.toggle('collapsed', !expanded);
-  document.getElementById('toolbar-toggle-icon').textContent = expanded ? '▾' : '▸';
-}
-
-function toggleToolbar() {
-  const expanded = document.getElementById('toolbar').classList.contains('collapsed');
-  applyToolbarState(expanded);
-  lsSet('toolbarExpanded', expanded);
 }
 
 function onShowTagsToggle() {


### PR DESCRIPTION
## Summary

- **Collection/Wishlist** promoted to top-level nav switch, always visible
- **Table/Tile** sub-view buttons now appear for both sections (wishlist tile view added)
- `currentSection` (`collection`|`wishlist`) decoupled from `currentView` (`table`|`tile`) — app always opens to Collection; wishlist is never persisted as the startup view
- Display settings (Clean Artists, Include P&P, Show Valuations, Hide Format Tags) are now staged — changes only apply when Save is clicked, not on toggle
- `show_valuations` promoted from localStorage to DB-backed setting (default `true`); auto-seeded via `INSERT OR IGNORE` on next restart, no migration needed

Closes #26

## Test plan

- [ ] App opens to Collection on fresh load / after clearing localStorage
- [ ] Collection → Table and Collection → Tiles both work as before
- [ ] Switching to Wishlist → Table shows sortable wishlist table
- [ ] Switching to Wishlist → Tiles shows cover art grid; clicking a tile opens detail modal
- [ ] Show Fulfilled toggle works in both wishlist views
- [ ] Switching sections clears the search bar
- [ ] Display settings in Settings modal: toggling does not immediately change the view — only Save applies them
- [ ] Show Valuations default is on; toggling off and saving hides the KPI and valuation column

🤖 Generated with [Claude Code](https://claude.com/claude-code)