### PR TITLE
feat(offline): full offline support — SW caching, wishlist queue, fulfilled toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ All outbound Discogs API calls go through `discogs_get()` / `discogs_post()` wra
 - Accepts `r12345678` or `12345678`
 - Makes 2 concurrent Discogs calls: `/releases/{id}` + `/marketplace/stats/{id}`
 - Returns artist, title, label, cat_no, year, format, cover_file, valuation, and `wishlist_match` (unfulfilled wishlist item matching this release's `master_id`, or null)
+- `wishlist_match` includes `{id, artist, title, notes}` — notes used for porting to collection record on fulfillment
 - Downloads and caches all images (up to 8) to `/data/images/`; populates `tracklist` table
 
 ### Record refresh (`/api/records/{id}/refresh`)
@@ -216,10 +217,14 @@ diffData          // last sync diff payload
 syncSource        // 'discogs' | 'csv' — controls sync modal behaviour
 hideObviousFormats // bool — global on/off for format tag hiding
 hiddenFormatTags  // Set<string> — tags to hide from filter bar
-wishlistItems     // array — full wishlist dataset from API (loaded on demand)
+wishlistItems     // array — merged server + pending items for display (rebuilt by loadWishlist)
 showFulfilled     // bool — show fulfilled items in wishlist view
 serverReachable   // bool — false when internet present but server unreachable
 _reachabilityPollTimer // setTimeout handle for backoff reachability polling
+pendingQueue      // array — in-memory mirror of IDB wishlist_queue (new items queued offline)
+pendingUpdates    // array — in-memory mirror of IDB wishlist_updates (edits queued offline)
+_serverWishlistItems  // array — last fetched server wishlist data; pendingUpdates applied on top
+_lastSearchResults    // array — last wishlist search results; used by addToWishlist for metadata
 ```
 
 Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within **both** sections. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. Only `'table'`/`'tile'` are saved to localStorage — app always opens to collection.
@@ -252,21 +257,30 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 | `importCsv(input)` | POST CSV → sets `syncSource='csv'` → opens sync modal |
 | `openSettings()` | Open settings modal; reloads field mapping in-place |
 | `saveSettings()` | Persist settings; stays open; refreshes field mapping if username changed |
-| `loadWishlist()` | Fetch `/api/wishlist`, update `wishlistItems`, update stats; calls `renderWishlist()` only if `currentSection === 'wishlist'` |
-| `renderWishlist()` | Delegates to `renderWishlistTiles()` when `currentView === 'tile'`, otherwise builds sortable table (cover, Artist, Title, Year, Added, Notes); no inline search filtering |
-| `renderWishlistTiles()` | Build wishlist cover art grid sorted artist → year; clicking a tile opens detail modal directly |
-| `openWishlistSearchModal(prefill)` | Open master release search modal; auto-searches if prefill provided |
-| `doWishlistSearch()` | POST to `/api/wishlist/search`, sort by year desc, render results with Add/On wishlist/Fulfilled state |
-| `addToWishlist(masterId)` | POST to `/api/wishlist`, close modal, clear search bar, reload wishlist |
-| `fulfillWishlistItem(id)` | PUT fulfilled=true, reload wishlist |
+| `loadWishlist()` | Fetch `/api/wishlist` (always tries — SW serves from cache if server down), apply `pendingUpdates`, merge `pendingQueue` items, rebuild `wishlistItems`, render and update stats |
+| `renderWishlist()` | Delegates to `renderWishlistTiles()` when `currentView === 'tile'`, otherwise builds sortable table; pending items show Pending badge instead of added date |
+| `renderWishlistTiles()` | Build wishlist cover art grid sorted artist → year; pending items show corner Pending badge and ⏳ placeholder if no thumb |
+| `openWishlistSearchModal(prefill)` | Open master release search modal; blocked only when `!navigator.onLine`; shows offline info banner when server unreachable |
+| `doWishlistSearch()` | When server reachable: calls `/api/wishlist/search`. When offline: calls Discogs API directly (unauthenticated, 25 req/min). Stores results in `_lastSearchResults` |
+| `addToWishlist(masterId)` | When online: POST to `/api/wishlist`. When offline: saves to IDB `wishlist_queue` via `saveToQueue()`, shows pending in list |
 | `deleteWishlistItem(id)` | DELETE item, reload wishlist |
-| `openWishlistDetail(id)` | Open detail modal: cover, metadata (year/genres/styles/lowest price), notes textarea, Mark Fulfilled + Delete + Save buttons |
+| `openWishlistDetail(id)` | Negative id → `openPendingWishlistDetail`. Otherwise: cover, metadata, fulfilled checkbox + notes textarea, Save (queues offline) + Delete (disabled offline) |
+| `openPendingWishlistDetail(id)` | Detail modal for IDB-queued items: thumb, metadata, editable notes (saved to IDB), Delete removes from queue — all works offline |
+| `openOfflineDB()` | Open IndexedDB `sn_offline` v2; creates `wishlist_queue` (autoIncrement) and `wishlist_updates` (keyed by `wishlist_id`) on upgrade |
+| `initPendingQueue()` | Load both IDB stores into `pendingQueue` and `pendingUpdates` on startup |
+| `saveToQueue(item)` | Add new wishlist item to IDB `wishlist_queue`, update `pendingQueue` in memory |
+| `removeFromQueue(idbKey)` | Delete from IDB `wishlist_queue`, update `pendingQueue` |
+| `saveUpdateToQueue(update)` | Upsert `{wishlist_id, notes, fulfilled}` to IDB `wishlist_updates`, update `pendingUpdates` |
+| `removeUpdateFromQueue(wishlistId)` | Delete from IDB `wishlist_updates`, update `pendingUpdates` |
+| `updateQueueItemNotes(idbKey, notes)` | Update notes on an existing IDB `wishlist_queue` item in place |
+| `flushPendingQueue()` | On reconnect: POST each `wishlist_queue` item, PUT each `wishlist_updates` item; removes from IDB on success/409; reloads wishlist and toasts count |
+| `splitDiscogsTitle(combined)` | Split "Artist - Title" Discogs search string into `{artist, title}` for pending item display |
 | `setSection(section)` | Top-level nav: sets `currentSection`, updates nav buttons, calls `applyToolbarSwitches`, loads/renders appropriate view |
 | `applyToolbarSwitches(s)` | Show/hide collection vs wishlist switches; `collection-view-toggle` always visible (both sections support Table/Tile); update search placeholder |
 | `apiFetch(url, opts)` | Wrapper around `fetch` for all `/api/` calls — catches `TypeError` and triggers `probeHealth()` if online |
 | `checkHealth()` | `fetch('/api/health')` with 5s timeout; returns bool — uses plain `fetch`, not `apiFetch`, to avoid recursion |
 | `probeHealth()` | Calls `checkHealth()` and passes result to `setServerReachable()` |
-| `setServerReachable(bool)` | Updates `serverReachable`, calls `updateOnlineState()`, starts/cancels backoff polling, toasts on reconnect |
+| `setServerReachable(bool)` | Updates `serverReachable`, calls `updateOnlineState()`, starts/cancels backoff polling, toasts on reconnect, calls `flushPendingQueue()` on reconnect |
 | `scheduleReachabilityCheck(attempt)` | Backoff poll: 10s → 30s → 60s; only runs while app is visible and server unreachable |
 | `updateOnlineState()` | Sets `body.offline` class and banner for both offline states; disables write actions |
 
@@ -285,8 +299,8 @@ Always visible (no collapse toggle). Single nav row: `[Collection] [Wishlist]` p
 - `modal-form` — add/edit form with Discogs lookup
 - `modal-discogs-sync` — diff preview; shared between Discogs collection sync and CSV import. `syncSource` controls labels and available actions (CSV hides "Discogs →" direction)
 - `modal-settings` — Display settings, Discogs config + field mapping, Data (import/export), Danger Zone. **Save stays open** (reload fields in-place); Close button dismisses.
-- `modal-wishlist-search` — Discogs master release search; results show Add/On wishlist/Fulfilled per item
-- `modal-wishlist-detail` — Wishlist item detail: cover, metadata, notes editing, Mark Fulfilled, Delete
+- `modal-wishlist-search` — Discogs master release search; results show Add/Queued/On wishlist/Fulfilled per item. Shows slate info banner when server unreachable (searching Discogs directly)
+- `modal-wishlist-detail` — Wishlist item detail: cover, metadata, fulfilled checkbox, notes textarea, Save + Delete. Save queues offline for server items; Delete disabled offline for server items, always enabled for pending items
 
 ### Settings modal sections (top to bottom)
 1. **Display** — Clean artists, Include P&P, Show Valuations, Hide format tags (toggle + tag list). **All display toggles are staged — state only applies on Save, not on toggle.**
@@ -308,28 +322,24 @@ S (Sealed) → M → NM → VG+ → VG → G+ → G → F → P
 - **SPA routing:** `GET /{full_path:path}` serves static files or falls back to `index.html`. API routes are defined before this catch-all.
 - **Empty DB:** `list_records` catches `OperationalError`, calls `init_db()`, returns `[]` rather than 500.
 - **No schema migrations:** `init_db()` uses `CREATE TABLE IF NOT EXISTS` only. Assume fresh installs. To reset: delete `/data/sleevenotes.db`.
-- **Wishlist fulfilled prompt:** When saving a new collection record, if the fetched Discogs release has a `master_id` matching an unfulfilled wishlist item (`wishlist_match` in the fetch response), the user is prompted to mark it fulfilled.
+- **Wishlist fulfilled prompt:** When saving a new collection record, if the fetched Discogs release has a `master_id` matching an unfulfilled wishlist item (`wishlist_match` in the fetch response), the user is prompted to mark it fulfilled. Wishlist `notes` are appended to the collection record's notes at the same time (empty collection notes → copy; existing notes → append with newline).
+- **Wishlist fulfilled toggle:** The detail modal shows a checkbox for fulfilled status, saved together with notes via the Save button. This replaces the former instant "Mark Fulfilled" action — changes are reversible until saved.
 - **Wishlist cover prefix:** Master release covers are stored as `m{master_id}_01.jpeg` to avoid filename collision with release images (`r{release_id}_...`).
-- **PWA:** `static/manifest.json`, `static/sw.js` (minimal — satisfies Chrome install requirement), `static/icon.svg`, `static/icon-192.png`, `static/icon-512.png`. Wishlist always fetches all items (`show_fulfilled=true`) and filters client-side so the fulfilled toggle works offline without re-fetching.
+- **Tracklist loading:** Fetched eagerly when a record detail modal opens (not gated on the Tracklist tab click), so the SW caches the response for offline use on that same visit.
+- **PWA / service worker (`static/sw.js`):**
+  - Install: precaches app shell (`/`, `manifest.json`, icons) — prevents pull-to-refresh showing the browser offline page
+  - `/images/*`: cache-first — cover images and any other record images load offline after first view
+  - `/api/records`, `/api/wishlist`, `/api/settings` (GET only): network-first with SW cache fallback — collection and wishlist survive page refresh with server down
+  - `/api/health`: always network-only — must hit the server for reachability detection
+  - All other `/api/*`: network-only (mutations, Discogs fetches, etc.)
+  - Background Sync: SW flushes both IDB queues (`wishlist-sync` tag) on Android when app is backgrounded
 - **Two-state offline detection:** The app distinguishes two offline states, each with its own banner:
   - **Read-Only Mode** (`navigator.onLine === false`) — no internet, amber banner `#7A4800`. Fully read-only.
-  - **Offline Mode** (`navigator.onLine === true` but `/api/health` fails) — server unreachable, slate banner `#3D4A5C`. Collection read-only; backbone for offline wishlist adding (#11).
-  - Both states set `body.offline` and disable all write actions.
+  - **Offline Mode** (`navigator.onLine === true` but `/api/health` fails) — server unreachable, slate banner `#3D4A5C`. Collection read-only from SW cache; wishlist search, add, and edit all work via IndexedDB queue.
+  - Both states set `body.offline` and disable collection write actions.
   - Detection is event-driven: probe on load, on `window 'online'`, on any `apiFetch` TypeError, and on `visibilitychange` visible. Backoff polling (10s → 30s → 60s) only runs while the app is visible and the server is unreachable — cancelled immediately on `visibilitychange` hidden so backgrounding the app stops all polling.
-
-## Feature Requests
-
-### Offline wishlist adding
-When the user is away from home on mobile (has internet but server is unreachable), they should be able to search for and queue wishlist items that sync to the server on reconnect.
-
-Two distinct offline states need separate detection and banners:
-- **No internet** (`navigator.onLine === false`) — fully read-only, Discogs unreachable
-- **Server unreachable** (`navigator.onLine === true` but `/api/health` probe fails) — read-only for collection, but wishlist adding possible
-
-Design notes:
-- `GET /api/health` and two-state offline detection are already implemented (v1.6.0)
-- Wishlist search calls Discogs directly from the browser (unauthenticated API, 25 req/min — fine for personal use) bypassing the backend. The Discogs token is never sent to the frontend, so anonymous mode is a deliberate fallback — do not cache the token client-side to increase the rate limit
-- Adds queued as `{master_id, notes, queued_at}` in IndexedDB; displayed in wishlist as pending placeholders (no cover/metadata yet)
-- On reconnect, queue flushed via `POST /api/wishlist` per item; 409 (already exists) swallowed silently
-- Background Sync API can flush queue even when app is closed (Android only — iOS does not support it)
-- Collision handling: if someone else added the same item while offline, user deletes the duplicate manually
+- **Offline wishlist queue (IndexedDB `sn_offline` v2):**
+  - `wishlist_queue` (autoIncrement key `idb_key`): new items added offline. Each record: `{master_id, notes, queued_at, title, year, thumb}`. Pending items merged into `wishlistItems` with negative IDs (`-(idb_key)`) for display.
+  - `wishlist_updates` (key `wishlist_id`): notes/fulfilled edits made offline. Upsert — only latest edit per item is kept. Applied to `_serverWishlistItems` before rendering so display reflects queued state immediately.
+  - Both queues flushed on reconnect via `flushPendingQueue()` and by Background Sync on Android.
+  - Discogs token never sent to browser; offline search uses unauthenticated Discogs API (25 req/min, no thumbnails returned — ♪ placeholder shown).

--- a/app.py
+++ b/app.py
@@ -796,11 +796,11 @@ async def fetch_discogs(release_id: str):
     if master_id:
         with get_db() as conn:
             row = conn.execute(
-                "SELECT id, artist, title FROM wishlist WHERE master_id = ? AND fulfilled = 0",
+                "SELECT id, artist, title, notes FROM wishlist WHERE master_id = ? AND fulfilled = 0",
                 (master_id,)
             ).fetchone()
             if row:
-                wishlist_match = {"id": row["id"], "artist": row["artist"], "title": row["title"]}
+                wishlist_match = {"id": row["id"], "artist": row["artist"], "title": row["title"], "notes": row["notes"]}
     return {
         "discogs_id": f"r{rid}",
         "artist": ", ".join(a["name"] for a in data.get("artists", [])),

--- a/static/index.html
+++ b/static/index.html
@@ -106,10 +106,7 @@
   body.offline #btn-settings,
   body.offline #detail-edit-btn,
   body.offline #delete-btn,
-  body.offline #btn-save-settings,
-  body.offline #wishlist-detail-delete-btn,
-  body.offline #wishlist-detail-fulfill-btn,
-  body.offline #wishlist-detail-save-btn {
+  body.offline #btn-save-settings {
     opacity: 0.45;
     pointer-events: none;
     cursor: not-allowed;
@@ -864,6 +861,8 @@
   .wishlist-row-fulfilled td { opacity: 0.4; }
   .badge-want { background: #FFF3CD; color: #856404; font-size: 9px; padding: 1px 5px; border: 1px solid #FFE69C; }
   .badge-fulfilled { background: #D4EDDA; color: var(--green); font-size: 9px; padding: 1px 5px; border: 1px solid #B8DFC5; }
+  .badge-pending { background: #FFF3CD; color: #856404; font-size: 9px; padding: 1px 5px; border: 1px solid #FFE69C; }
+  .tile-pending-badge { position: absolute; top: 0.4rem; right: 0.4rem; background: rgba(133,100,4,0.9); color: #fff; font-size: 9px; font-weight: 600; padding: 2px 6px; border-radius: 3px; letter-spacing: 0.03em; pointer-events: none; }
 
   /* ── Misc ── */
   .spinner {
@@ -1363,8 +1362,7 @@
       <button class="btn btn-danger btn-sm" id="wishlist-detail-delete-btn">Delete</button>
       <div style="display:flex;gap:0.5rem">
         <button class="btn btn-secondary" onclick="closeModal('modal-wishlist-detail')">Close</button>
-        <button class="btn btn-secondary" id="wishlist-detail-fulfill-btn">Mark Fulfilled</button>
-        <button class="btn btn-primary" id="wishlist-detail-save-btn">Save Notes</button>
+        <button class="btn btn-primary" id="wishlist-detail-save-btn">Save</button>
       </div>
     </div>
   </div>
@@ -1378,6 +1376,9 @@
       <button class="btn btn-ghost btn-icon" onclick="closeModal('modal-wishlist-search')">✕</button>
     </div>
     <div class="modal-body">
+      <div id="wishlist-search-offline-banner" style="display:none;margin-bottom:0.75rem;padding:0.5rem 0.75rem;background:#3D4A5C;color:#fff;border-radius:var(--radius);font-size:12px;line-height:1.4">
+        Server unreachable — searching Discogs directly. Items you add will sync when you're back home.
+      </div>
       <div style="display:flex;gap:0.5rem;margin-bottom:1rem">
         <input class="form-control" id="wishlist-search-input" placeholder="Artist, album title…" onkeydown="if(event.key==='Enter')doWishlistSearch()">
         <button class="btn btn-primary btn-sm" onclick="doWishlistSearch()" id="wishlist-search-btn">Search</button>
@@ -1414,6 +1415,10 @@ let wishlistItems = [];
 let showFulfilled = false;
 let serverReachable = true;
 let _reachabilityPollTimer = null;
+let pendingQueue = [];
+let pendingUpdates = [];
+let _serverWishlistItems = [];
+let _lastSearchResults = [];
 
 // ── localStorage helpers ────────────────────────────────────────────────────
 function lsGet(key, fallback) {
@@ -1422,6 +1427,142 @@ function lsGet(key, fallback) {
 }
 function lsSet(key, val) {
   try { localStorage.setItem('sn_' + key, JSON.stringify(val)); } catch {}
+}
+
+// ── IndexedDB offline queue ─────────────────────────────────────────────────
+function openOfflineDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('sn_offline', 2);
+    req.onupgradeneeded = e => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains('wishlist_queue'))
+        db.createObjectStore('wishlist_queue', { keyPath: 'idb_key', autoIncrement: true });
+      if (!db.objectStoreNames.contains('wishlist_updates'))
+        db.createObjectStore('wishlist_updates', { keyPath: 'wishlist_id' });
+    };
+    req.onsuccess = e => resolve(e.target.result);
+    req.onerror = reject;
+  });
+}
+
+async function initPendingQueue() {
+  try {
+    const db = await openOfflineDB();
+    const load = store => new Promise((resolve, reject) => {
+      const req = db.transaction(store, 'readonly').objectStore(store).getAll();
+      req.onsuccess = e => resolve(e.target.result);
+      req.onerror = reject;
+    });
+    [pendingQueue, pendingUpdates] = await Promise.all([
+      load('wishlist_queue'),
+      load('wishlist_updates'),
+    ]);
+  } catch { pendingQueue = []; pendingUpdates = []; }
+}
+
+async function saveUpdateToQueue(update) {
+  const entry = { ...update, queued_at: new Date().toISOString() };
+  const db = await openOfflineDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction('wishlist_updates', 'readwrite');
+    tx.objectStore('wishlist_updates').put(entry);
+    tx.oncomplete = resolve;
+    tx.onerror = reject;
+  });
+  const idx = pendingUpdates.findIndex(u => u.wishlist_id === update.wishlist_id);
+  if (idx >= 0) pendingUpdates[idx] = entry; else pendingUpdates.push(entry);
+}
+
+async function removeUpdateFromQueue(wishlistId) {
+  const db = await openOfflineDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction('wishlist_updates', 'readwrite');
+    tx.objectStore('wishlist_updates').delete(wishlistId);
+    tx.oncomplete = resolve;
+    tx.onerror = reject;
+  });
+  pendingUpdates = pendingUpdates.filter(u => u.wishlist_id !== wishlistId);
+}
+
+async function saveToQueue(item) {
+  const db = await openOfflineDB();
+  const key = await new Promise((resolve, reject) => {
+    const tx = db.transaction('wishlist_queue', 'readwrite');
+    const req = tx.objectStore('wishlist_queue').add(item);
+    req.onsuccess = e => resolve(e.target.result);
+    req.onerror = reject;
+  });
+  item.idb_key = key;
+  pendingQueue.push(item);
+}
+
+async function removeFromQueue(idbKey) {
+  const db = await openOfflineDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction('wishlist_queue', 'readwrite');
+    tx.objectStore('wishlist_queue').delete(idbKey);
+    tx.oncomplete = resolve;
+    tx.onerror = reject;
+  });
+  pendingQueue = pendingQueue.filter(p => p.idb_key !== idbKey);
+}
+
+async function updateQueueItemNotes(idbKey, notes) {
+  const db = await openOfflineDB();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction('wishlist_queue', 'readwrite');
+    const store = tx.objectStore('wishlist_queue');
+    const req = store.get(idbKey);
+    req.onsuccess = e => {
+      store.put({ ...e.target.result, notes });
+      tx.oncomplete = resolve;
+      tx.onerror = reject;
+    };
+    req.onerror = reject;
+  });
+  const item = pendingQueue.find(p => p.idb_key === idbKey);
+  if (item) item.notes = notes;
+}
+
+async function flushPendingQueue() {
+  if (!pendingQueue.length && !pendingUpdates.length) return;
+  let synced = 0, failed = 0;
+
+  for (const item of [...pendingQueue]) {
+    try {
+      const r = await apiFetch('/api/wishlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ master_id: item.master_id, notes: item.notes || '' }),
+      });
+      if (r.ok || r.status === 409) { await removeFromQueue(item.idb_key); synced++; }
+      else failed++;
+    } catch { failed++; }
+  }
+
+  for (const upd of [...pendingUpdates]) {
+    try {
+      const r = await apiFetch(`/api/wishlist/${upd.wishlist_id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ notes: upd.notes, fulfilled: upd.fulfilled }),
+      });
+      if (r.ok) { await removeUpdateFromQueue(upd.wishlist_id); synced++; }
+      else failed++;
+    } catch { failed++; }
+  }
+
+  if (synced) {
+    await loadWishlist();
+    toast(`${synced} queued item${synced > 1 ? 's' : ''} synced`, 'success');
+  }
+  if (failed) toast(`${failed} item${failed > 1 ? 's' : ''} failed to sync`, 'error');
+}
+
+function splitDiscogsTitle(combined) {
+  const idx = combined.indexOf(' - ');
+  if (idx === -1) return { artist: combined, title: '' };
+  return { artist: combined.slice(0, idx), title: combined.slice(idx + 3) };
 }
 
 function restoreLocalState() {
@@ -1446,6 +1587,7 @@ function restoreLocalState() {
 // ── Init ───────────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', async () => {
   restoreLocalState();
+  await initPendingQueue();
   updateOnlineState();
   probeHealth();
   await loadSettings();
@@ -1652,7 +1794,7 @@ function applyToolbarSwitches(s) {
   document.getElementById('wishlist-switches').style.display = isWishlist ? 'contents' : 'none';
   document.getElementById('group-by-wrapper').style.display = (!isWishlist && currentView === 'table') ? '' : 'none';
   document.getElementById('search').placeholder = isWishlist
-    ? 'Search for a master release…'
+    ? 'Search for a record…'
     : 'Search artist, title, label…';
 }
 
@@ -1843,17 +1985,12 @@ async function openDetail(id) {
     </div>`;
 
   // Tab switching
-  let tracklistLoaded = false;
   document.querySelectorAll('.detail-tab-btn').forEach(btn => {
     btn.addEventListener('click', () => {
       document.querySelectorAll('.detail-tab-btn').forEach(b => b.classList.remove('active'));
       document.querySelectorAll('.detail-tab-panel').forEach(p => p.classList.remove('active'));
       btn.classList.add('active');
       document.getElementById(btn.dataset.panel).classList.add('active');
-      if (btn.dataset.panel === 'detail-panel-tracklist' && !tracklistLoaded) {
-        tracklistLoaded = true;
-        loadTracklist(id);
-      }
     });
   });
 
@@ -1878,7 +2015,8 @@ async function openDetail(id) {
 
   openModal('modal-detail');
 
-  // Async: fetch images and upgrade cover slot to carousel if multiple exist
+  // Async: fetch tracklist and images in background (warms SW cache for offline use)
+  loadTracklist(id);
   try {
     const resp = await apiFetch(`/api/records/${id}/images`);
     if (resp.ok) {
@@ -2109,18 +2247,34 @@ async function saveRecord() {
     });
     if (!r.ok) throw new Error();
     const wasNew = !editingId;
+    const savedId = wasNew ? (await r.json()).id : editingId;
     const match = wasNew ? fetchedMeta.wishlist_match : null;
     closeModal('modal-form');
     await loadRecords();
     toast(editingId ? 'Record updated' : 'Record added', 'success');
     if (match) {
       if (confirm(`"${match.artist} — ${match.title}" is on your wishlist. Mark as fulfilled?`)) {
-        await apiFetch(`/api/wishlist/${match.id}`, {
-          method: 'PUT',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({ fulfilled: true }),
-        }).catch(() => {});
-        await loadWishlist();
+        const wishlistNotes = match.notes || '';
+        const existingNotes = payload.notes || '';
+        const combinedNotes = wishlistNotes
+          ? (existingNotes ? `${existingNotes}\n${wishlistNotes}` : wishlistNotes)
+          : null;
+        const ps = [
+          apiFetch(`/api/wishlist/${match.id}`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ fulfilled: true }),
+          }).catch(() => {}),
+        ];
+        if (combinedNotes !== null) {
+          ps.push(apiFetch(`/api/records/${savedId}`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ ...payload, notes: combinedNotes }),
+          }).catch(() => {}));
+        }
+        await Promise.all(ps);
+        await Promise.all([loadRecords(), loadWishlist()]);
         toast('Marked as fulfilled', 'success');
       }
     }
@@ -2715,19 +2869,39 @@ async function doClearImages() {
 // ── Wishlist ───────────────────────────────────────────────────────────────
 
 async function loadWishlist() {
-  if (!navigator.onLine || !serverReachable) {
-    if (currentSection === 'wishlist') renderWishlist();
-    updateStats();
-    return;
-  }
   try {
     const r = await apiFetch('/api/wishlist?show_fulfilled=true');
     if (!r.ok) throw new Error();
-    wishlistItems = await r.json();
+    _serverWishlistItems = await r.json();
   } catch {
-    wishlistItems = [];
-    if (currentSection === 'wishlist') toast('Failed to load wishlist', 'error');
+    if (!_serverWishlistItems.length && currentSection === 'wishlist')
+      toast('Failed to load wishlist', 'error');
   }
+  for (const upd of pendingUpdates) {
+    const item = _serverWishlistItems.find(w => w.id === upd.wishlist_id);
+    if (item) { item.notes = upd.notes; item.fulfilled = !!upd.fulfilled; }
+  }
+  const serverMasterIds = new Set(_serverWishlistItems.map(w => String(w.master_id)));
+  const pending = pendingQueue
+    .filter(p => !serverMasterIds.has(String(p.master_id)))
+    .map(p => {
+      const { artist, title } = splitDiscogsTitle(p.title || '');
+      return {
+        id: -(p.idb_key),
+        master_id: p.master_id,
+        artist,
+        title,
+        year: p.year,
+        cover_file: null,
+        thumb: p.thumb || '',
+        notes: p.notes || '',
+        added_at: p.queued_at,
+        fulfilled: false,
+        pending: true,
+        idb_key: p.idb_key,
+      };
+    });
+  wishlistItems = [..._serverWishlistItems, ...pending];
   if (currentSection === 'wishlist') renderWishlist();
   updateStats();
 }
@@ -2748,9 +2922,10 @@ function renderWishlistTiles() {
 
   el.innerHTML = `<div class="tile-grid">${items.map(w => `
     <div class="tile" onclick="openWishlistDetail(${w.id})">
-      ${w.cover_file
-        ? `<img class="tile-img" src="/images/${esc(w.cover_file)}" alt="${esc(w.artist)} - ${esc(w.title)}" loading="lazy">`
-        : `<div class="tile-placeholder">♡</div>`}
+      ${w.pending
+        ? (w.thumb ? `<img class="tile-img" src="${esc(w.thumb)}" alt="${esc(w.artist)} - ${esc(w.title)}" loading="lazy">` : `<div class="tile-placeholder">⏳</div>`)
+        : (w.cover_file ? `<img class="tile-img" src="/images/${esc(w.cover_file)}" alt="${esc(w.artist)} - ${esc(w.title)}" loading="lazy">` : `<div class="tile-placeholder">♡</div>`)}
+      ${w.pending ? `<div class="tile-pending-badge">Pending</div>` : ''}
       <div class="tile-overlay">
         <div class="tile-overlay-artist">${esc(w.artist)}</div>
         <div class="tile-overlay-title">${esc(w.title)}</div>
@@ -2783,11 +2958,13 @@ function renderWishlist() {
 
   const rows = items.map(w => `
     <tr class="${w.fulfilled ? 'wishlist-row-fulfilled' : ''} data-row" style="cursor:pointer" onclick="openWishlistDetail(${w.id})">
-      <td>${w.cover_file ? `<img class="cover-thumb" src="/images/${esc(w.cover_file)}" alt="" loading="lazy">` : `<div class="cover-placeholder">♡</div>`}</td>
+      <td>${w.pending
+        ? (w.thumb ? `<img class="cover-thumb" src="${esc(w.thumb)}" alt="" loading="lazy">` : `<div class="cover-placeholder">⏳</div>`)
+        : (w.cover_file ? `<img class="cover-thumb" src="/images/${esc(w.cover_file)}" alt="" loading="lazy">` : `<div class="cover-placeholder">♡</div>`)}</td>
       <td class="overflow" title="${esc(w.artist)}">${esc(w.artist)}</td>
       <td class="overflow" title="${esc(w.title)}">${esc(w.title)}</td>
       <td class="text-mono col-sm">${w.year || '—'}</td>
-      <td class="text-mono col-sm">${fmtDate(w.added_at ? w.added_at.split(' ')[0] : '')}</td>
+      <td class="text-mono col-sm">${w.pending ? '<span class="badge badge-pending">Pending</span>' : fmtDate(w.added_at ? w.added_at.split(' ')[0] : '')}</td>
       <td class="note-cell col-md" title="${esc(w.notes)}">${esc(w.notes)}</td>
     </tr>`).join('');
 
@@ -2810,10 +2987,11 @@ function renderWishlist() {
 }
 
 function openWishlistSearchModal(prefill = '') {
-  if (!navigator.onLine || !serverReachable) { toast('Offline — wishlist search requires a connection', 'error'); return; }
+  if (!navigator.onLine) { toast('No internet — wishlist search is unavailable offline', 'error'); return; }
   const input = document.getElementById('wishlist-search-input');
   input.value = prefill;
   document.getElementById('wishlist-search-results').innerHTML = '';
+  document.getElementById('wishlist-search-offline-banner').style.display = serverReachable ? 'none' : '';
   openModal('modal-wishlist-search');
   input.focus();
   if (prefill) doWishlistSearch();
@@ -2828,9 +3006,27 @@ async function doWishlistSearch() {
   btn.innerHTML = '<span class="spinner"></span>';
   results.innerHTML = '<div style="color:var(--ink-light);font-size:13px;padding:0.5rem 0">Searching…</div>';
   try {
-    const r = await apiFetch(`/api/wishlist/search?q=${encodeURIComponent(q)}`);
-    if (!r.ok) throw new Error();
-    const items = await r.json();
+    let items;
+    if (!serverReachable) {
+      const resp = await fetch(
+        `https://api.discogs.com/database/search?type=master&per_page=10&q=${encodeURIComponent(q)}`,
+        { headers: { 'User-Agent': 'SleeveNotes/1.0' } }
+      );
+      if (!resp.ok) throw new Error();
+      const data = await resp.json();
+      items = (data.results || []).map(r => ({
+        master_id: String(r.master_id || r.id),
+        title: r.title || '',
+        year: r.year,
+        thumb: r.thumb || '',
+        cover_image: r.cover_image || '',
+      }));
+    } else {
+      const r = await apiFetch(`/api/wishlist/search?q=${encodeURIComponent(q)}`);
+      if (!r.ok) throw new Error();
+      items = await r.json();
+    }
+    _lastSearchResults = items;
     items.sort((a, b) => (parseInt(b.year) || 0) - (parseInt(a.year) || 0));
     if (!items.length) {
       results.innerHTML = '<div style="color:var(--ink-light);font-size:13px;padding:0.5rem 0">No results found.</div>';
@@ -2847,12 +3043,12 @@ async function doWishlistSearch() {
           <div style="font-size:11px;color:var(--ink-light);font-family:var(--font-mono)">${item.year ? item.year + ' · ' : ''}master ${esc(item.master_id)}</div>
         </div>
         ${existingItem
-          ? `<span style="font-size:12px;color:var(--ink-light);white-space:nowrap;flex-shrink:0">${existingItem.fulfilled ? 'Fulfilled' : 'On wishlist'}</span>`
+          ? `<span style="font-size:12px;color:var(--ink-light);white-space:nowrap;flex-shrink:0">${existingItem.fulfilled ? 'Fulfilled' : existingItem.pending ? 'Queued' : 'On wishlist'}</span>`
           : `<button class="btn btn-primary btn-sm" style="flex-shrink:0" onclick="addToWishlist('${esc(item.master_id)}')">Add</button>`}
       </div>`;
     }).join('');
   } catch {
-    results.innerHTML = '<div style="color:var(--red);font-size:13px;padding:0.5rem 0">Search failed — check your Discogs token in Settings.</div>';
+    results.innerHTML = `<div style="color:var(--red);font-size:13px;padding:0.5rem 0">${serverReachable ? 'Search failed — check your Discogs token in Settings.' : 'Search failed — Discogs may be unreachable.'}</div>`;
   } finally {
     btn.disabled = false;
     btn.textContent = 'Search';
@@ -2860,6 +3056,31 @@ async function doWishlistSearch() {
 }
 
 async function addToWishlist(masterId) {
+  if (!serverReachable) {
+    if (pendingQueue.some(p => String(p.master_id) === String(masterId))) {
+      toast('Already queued', 'error'); return;
+    }
+    if (_serverWishlistItems.some(w => String(w.master_id) === String(masterId))) {
+      toast('Already on wishlist', 'error'); return;
+    }
+    const item = _lastSearchResults.find(r => String(r.master_id) === String(masterId));
+    await saveToQueue({
+      master_id: masterId,
+      notes: '',
+      queued_at: new Date().toISOString(),
+      title: item?.title || '',
+      year: item?.year || null,
+      thumb: item?.thumb || '',
+    });
+    if ('serviceWorker' in navigator && 'SyncManager' in window) {
+      navigator.serviceWorker.ready.then(sw => sw.sync.register('wishlist-sync').catch(() => {}));
+    }
+    closeModal('modal-wishlist-search');
+    document.getElementById('search').value = '';
+    await loadWishlist();
+    toast('Added — will sync when back home', 'success');
+    return;
+  }
   try {
     const r = await apiFetch('/api/wishlist', {
       method: 'POST',
@@ -2911,6 +3132,7 @@ function onShowFulfilledToggle() {
 }
 
 function openWishlistDetail(id) {
+  if (id < 0) { openPendingWishlistDetail(id); return; }
   const w = wishlistItems.find(x => x.id === id);
   if (!w) return;
 
@@ -2926,9 +3148,10 @@ function openWishlistDetail(id) {
         <div class="detail-artist">${esc(w.artist)}</div>
         <div class="detail-title">${esc(w.title)}</div>
         <div style="margin:0.5rem 0">
-          ${w.fulfilled
-            ? '<span class="badge badge-fulfilled">Fulfilled</span>'
-            : '<span class="badge badge-want">Want</span>'}
+          <label style="display:flex;align-items:center;gap:0.4rem;cursor:pointer;font-size:13px">
+            <input type="checkbox" id="wishlist-detail-fulfilled" ${w.fulfilled ? 'checked' : ''}>
+            Fulfilled
+          </label>
         </div>
         ${w.year ? `<div class="detail-row"><span class="detail-key">Year</span><span class="detail-val">${w.year}</span></div>` : ''}
         ${w.genres ? `<div class="detail-row"><span class="detail-key">Genres</span><span class="detail-val">${esc(w.genres)}</span></div>` : ''}
@@ -2943,14 +3166,9 @@ function openWishlistDetail(id) {
       <textarea class="form-control" id="wishlist-detail-notes" rows="3" style="resize:vertical">${esc(w.notes || '')}</textarea>
     </div>`;
 
-  const fulfillBtn = document.getElementById('wishlist-detail-fulfill-btn');
-  fulfillBtn.style.display = w.fulfilled ? 'none' : '';
-  fulfillBtn.onclick = async () => {
-    closeModal('modal-wishlist-detail');
-    await fulfillWishlistItem(id);
-  };
-
-  document.getElementById('wishlist-detail-delete-btn').onclick = async () => {
+  const deleteBtn = document.getElementById('wishlist-detail-delete-btn');
+  deleteBtn.disabled = !serverReachable;
+  deleteBtn.onclick = async () => {
     if (!confirm('Remove this item from your wishlist?')) return;
     closeModal('modal-wishlist-detail');
     try {
@@ -2964,18 +3182,70 @@ function openWishlistDetail(id) {
 
   document.getElementById('wishlist-detail-save-btn').onclick = async () => {
     const notes = document.getElementById('wishlist-detail-notes').value;
+    const fulfilled = document.getElementById('wishlist-detail-fulfilled').checked;
+    if (!serverReachable) {
+      await saveUpdateToQueue({ wishlist_id: id, notes, fulfilled });
+      if ('serviceWorker' in navigator && 'SyncManager' in window)
+        navigator.serviceWorker.ready.then(sw => sw.sync.register('wishlist-sync').catch(() => {}));
+      await loadWishlist();
+      toast('Saved — will sync when back home', 'success');
+      return;
+    }
     try {
       const r = await apiFetch(`/api/wishlist/${id}`, {
         method: 'PUT',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ notes }),
+        body: JSON.stringify({ notes, fulfilled }),
       });
       if (!r.ok) throw new Error();
       await loadWishlist();
-      toast('Notes saved', 'success');
+      toast('Saved', 'success');
     } catch {
-      toast('Failed to save notes', 'error');
+      toast('Failed to save', 'error');
     }
+  };
+
+  openModal('modal-wishlist-detail');
+}
+
+function openPendingWishlistDetail(id) {
+  const w = wishlistItems.find(x => x.id === id);
+  if (!w) return;
+
+  document.getElementById('wishlist-detail-title').textContent = w.artist || w.title;
+  document.getElementById('wishlist-detail-body').innerHTML = `
+    <div class="detail-layout" style="margin-bottom:1.25rem">
+      <div>
+        ${w.thumb
+          ? `<img class="detail-cover" src="${esc(w.thumb)}" alt="cover">`
+          : `<div class="detail-cover-placeholder">⏳</div>`}
+      </div>
+      <div class="detail-fields">
+        <div class="detail-artist">${esc(w.artist)}</div>
+        <div class="detail-title">${esc(w.title)}</div>
+        <div style="margin:0.5rem 0"><span class="badge badge-pending">Pending sync</span></div>
+        ${w.year ? `<div class="detail-row"><span class="detail-key">Year</span><span class="detail-val">${w.year}</span></div>` : ''}
+        <div class="detail-row"><span class="detail-key">Master</span><span class="detail-val"><a class="discogs-link" href="https://www.discogs.com/master/${esc(w.master_id)}" target="_blank">m${esc(w.master_id)}</a></span></div>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Notes</label>
+      <textarea class="form-control" id="wishlist-detail-notes" rows="3" style="resize:vertical">${esc(w.notes || '')}</textarea>
+    </div>`;
+
+  document.getElementById('wishlist-detail-delete-btn').onclick = async () => {
+    if (!confirm('Remove this queued item?')) return;
+    closeModal('modal-wishlist-detail');
+    await removeFromQueue(w.idb_key);
+    await loadWishlist();
+    toast('Removed from queue', 'success');
+  };
+
+  document.getElementById('wishlist-detail-save-btn').onclick = async () => {
+    const notes = document.getElementById('wishlist-detail-notes').value;
+    await updateQueueItemNotes(w.idb_key, notes);
+    await loadWishlist();
+    toast('Notes saved', 'success');
   };
 
   openModal('modal-wishlist-detail');
@@ -3157,7 +3427,10 @@ function setServerReachable(reachable) {
   _reachabilityPollTimer = null;
   updateOnlineState();
   if (!reachable && !document.hidden) scheduleReachabilityCheck(0);
-  if (wasUnreachable && reachable) toast('Server reconnected', 'success');
+  if (wasUnreachable && reachable) {
+    toast('Server reconnected', 'success');
+    flushPendingQueue();
+  }
 }
 
 function scheduleReachabilityCheck(attempt) {

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,2 +1,126 @@
-self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', e => e.waitUntil(clients.claim()));
+const CACHE = 'sn-v1';
+const SHELL = ['/', '/manifest.json', '/icon.svg', '/icon-192.png', '/icon-512.png'];
+
+self.addEventListener('install', e => {
+  self.skipWaiting();
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(SHELL)));
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => clients.claim())
+  );
+});
+
+self.addEventListener('fetch', e => {
+  const url = new URL(e.request.url);
+
+  // Health endpoint must always hit the network — it's used for reachability detection
+  if (url.pathname === '/api/health') return;
+
+  // Cache read-only data endpoints (network-first, cache fallback)
+  const CACHED_DATA = ['/api/records', '/api/wishlist', '/api/settings'];
+  if (e.request.method === 'GET' && CACHED_DATA.some(p => url.pathname.startsWith(p))) {
+    e.respondWith(
+      fetch(e.request).then(resp => {
+        if (resp.ok) caches.open(CACHE).then(c => c.put(e.request, resp.clone()));
+        return resp;
+      }).catch(() => caches.match(e.request))
+    );
+    return;
+  }
+
+  // Never cache other API calls (mutations, Discogs fetches, etc.)
+  if (url.pathname.startsWith('/api/')) return;
+
+  // Cache-first for images served by the backend
+  if (url.pathname.startsWith('/images/')) {
+    e.respondWith(
+      caches.open(CACHE).then(async cache => {
+        const cached = await cache.match(e.request);
+        if (cached) return cached;
+        const resp = await fetch(e.request);
+        if (resp.ok) cache.put(e.request, resp.clone());
+        return resp;
+      })
+    );
+    return;
+  }
+
+  // Network-first for everything else (app shell) with cache fallback
+  e.respondWith(
+    fetch(e.request)
+      .then(resp => {
+        if (resp.ok) caches.open(CACHE).then(c => c.put(e.request, resp.clone()));
+        return resp;
+      })
+      .catch(() => caches.match(e.request))
+  );
+});
+
+// Background Sync — flush offline wishlist queue (Android Chrome only)
+self.addEventListener('sync', e => {
+  if (e.tag === 'wishlist-sync') e.waitUntil(flushOfflineQueue());
+});
+
+function openSwDB() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open('sn_offline', 2);
+    req.onupgradeneeded = e => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains('wishlist_queue'))
+        db.createObjectStore('wishlist_queue', { keyPath: 'idb_key', autoIncrement: true });
+      if (!db.objectStoreNames.contains('wishlist_updates'))
+        db.createObjectStore('wishlist_updates', { keyPath: 'wishlist_id' });
+    };
+    req.onsuccess = e => resolve(e.target.result);
+    req.onerror = reject;
+  });
+}
+
+function swGetAll(db, store) {
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(store, 'readonly').objectStore(store).getAll();
+    req.onsuccess = e => resolve(e.target.result);
+    req.onerror = reject;
+  });
+}
+
+function swDelete(db, store, key) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(store, 'readwrite');
+    tx.objectStore(store).delete(key);
+    tx.oncomplete = resolve;
+    tx.onerror = reject;
+  });
+}
+
+async function flushOfflineQueue() {
+  try {
+    const db = await openSwDB();
+
+    for (const item of await swGetAll(db, 'wishlist_queue')) {
+      try {
+        const r = await fetch('/api/wishlist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ master_id: item.master_id, notes: item.notes || '' }),
+        });
+        if (r.ok || r.status === 409) await swDelete(db, 'wishlist_queue', item.idb_key);
+      } catch { /* retry on next sync */ }
+    }
+
+    for (const upd of await swGetAll(db, 'wishlist_updates')) {
+      try {
+        const r = await fetch(`/api/wishlist/${upd.wishlist_id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ notes: upd.notes, fulfilled: upd.fulfilled }),
+        });
+        if (r.ok) await swDelete(db, 'wishlist_updates', upd.wishlist_id);
+      } catch { /* retry on next sync */ }
+    }
+  } catch { /* IDB unavailable */ }
+}


### PR DESCRIPTION
## Summary

Closes #11, closes #25. Ships alongside PR #31 (feat/nav-restructure) as v1.7.0.

### This PR — offline support
- **Service worker rewritten** — app shell precached on install (fixes pull-to-refresh showing the browser offline page); cache-first for `/images/*`; network-first with SW fallback for `/api/records`, `/api/wishlist`, `/api/settings`. Collection and wishlist now survive a page refresh with the server down. `/api/health` deliberately excluded from cache.
- **Offline wishlist queue (IndexedDB)** — two stores in `sn_offline` v2: `wishlist_queue` for new items added offline, `wishlist_updates` for notes/fulfilled edits made offline. Both flushed on server reconnect and via Background Sync (Android). Pending items shown in table and tile views with a Pending badge.
- **Offline wishlist search** — when server unreachable, search modal calls the unauthenticated Discogs API directly from the browser. Token never sent to frontend. No thumbnails in offline search results (unauthenticated API limitation — ♪ placeholder shown).
- **Wishlist fulfilled → reversible toggle** — replaced the instant "Mark Fulfilled" button with a checkbox saved alongside notes via a single Save button.
- **Wishlist note porting** — when marking a wishlist item fulfilled after a collection add, its notes are appended to the collection record's notes automatically.
- **Tracklist eager loading** — fetched in the background when a record detail opens (not gated on tab click), so the SW caches it for offline use on the same visit.

### PR #31 — nav restructure
- **Two-level nav** — Collection and Wishlist are now top-level switches; Table and Tile are sub-views available in both sections
- **Wishlist tile view** — wishlist can now be browsed as a cover art grid; single tap opens the detail modal directly
- **Deferred display settings** — toggles in the Settings modal no longer apply immediately; state commits only on Save

## Known limitation

Offline wishlist search returns no thumbnails — the unauthenticated Discogs API does not return image URLs. The ♪ placeholder is shown instead.

## v1.7.0 release note (human summary)

> **A better experience everywhere, including offline.** The wishlist now has its own prominent place in the navigation alongside your collection, and both views support the cover art tile layout. Display settings no longer change as you toggle them — they apply when you hit Save.
>
> SleeveNotes also works much more usefully when you're away from home. Your collection and wishlist load from cache even if the server is unreachable. You can search for records on Discogs, add them to your wishlist, and edit wishlist notes and fulfilled status — all offline. Everything syncs automatically when your server comes back online. Pull-to-refresh no longer shows a browser error page.

## Test plan

- [ ] Load app online, open several record details (warms tracklist cache), browse wishlist
- [ ] Stop server — slate banner appears within ~10s
- [ ] Page refresh — app shell loads from SW cache, collection and wishlist visible
- [ ] Tracklist tab on a previously-opened record — shows cached data
- [ ] Wishlist search → results via direct Discogs (no thumbnails expected)
- [ ] Add item offline → Pending badge in list, detail modal opens, notes editable
- [ ] Edit notes/fulfilled on a server wishlist item offline → Save queues update
- [ ] Start server → reconnect toast → pending items flush, wishlist reloads correctly
- [ ] Add record matching a wishlist item → fulfill prompt → wishlist notes appended to record
- [ ] Collection/Wishlist top-level nav switches work; Table/Tile available in both sections
- [ ] Display settings in Settings modal only apply on Save, not on toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)