### PR TITLE
fix: remove backdrop click-to-close on all modals

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1646,24 +1646,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   await loadSettings();
   loadRecords();
   loadWishlist();
-  document.getElementById('modal-detail').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-detail');
-  });
-  document.getElementById('modal-form').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-form');
-  });
-  document.getElementById('modal-settings').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-settings');
-  });
-  document.getElementById('modal-discogs-sync').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-discogs-sync');
-  });
-  document.getElementById('modal-wishlist-detail').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-wishlist-detail');
-  });
-  document.getElementById('modal-wishlist-search').addEventListener('click', e => {
-    if (e.target === e.currentTarget) closeModal('modal-wishlist-search');
-  });
   document.getElementById('search').addEventListener('keydown', e => {
     if (e.key === 'Enter' && currentSection === 'wishlist') {
       openWishlistSearchModal(document.getElementById('search').value.trim());


### PR DESCRIPTION
## Summary
- Removes the backdrop click-to-close behaviour from all six modals
- Prevents drag-selecting text in form fields from accidentally dismissing the modal
- Consistent behaviour across all modals — dismiss via ✕ or Cancel/Close buttons only

## Test plan
- [ ] Open the add/edit record form, drag-select text in a field — modal should stay open
- [ ] Open settings, drag-select text — modal should stay open
- [ ] Open wishlist detail, drag-select notes — modal should stay open
- [ ] Confirm ✕ and Cancel/Close buttons still dismiss all modals correctly

Relates to #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)