### PR TITLE
fix: strip square brackets from Discogs release ID input

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2219,8 +2219,9 @@ function resetForm() {
 }
 
 async function fetchDiscogs() {
-  const rid = document.getElementById('f-discogs-id').value.trim();
+  const rid = document.getElementById('f-discogs-id').value.trim().replace(/^\[|\]$/g, '');
   if (!rid) { toast('Enter a Discogs release ID', 'error'); return; }
+  document.getElementById('f-discogs-id').value = rid;
   const btn = document.getElementById('fetch-btn');
   btn.innerHTML = '<span class="spinner"></span>';
   btn.disabled = true;


### PR DESCRIPTION
## Summary
- Strips leading `[` and trailing `]` from the release ID field before fetching
- Allows pasting Discogs-copied IDs (e.g. `[r37163484]`) directly without manual editing
- Cleaned value is written back to the field so the user sees the normalised ID

## Test plan
- [ ] Paste a square-bracketed ID e.g. `[r37163484]` into the Discogs Release ID field and click Fetch — should resolve correctly
- [ ] Confirm the field updates to show the stripped ID e.g. `r37163484`
- [ ] Confirm normal IDs (with and without `r` prefix) still work as before

Relates to #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)