### PR TITLE
feat: show dev environment banner when SN_DEV is set

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import io
 import csv
 import json
+import os
 import re
 import sqlite3
 import asyncio
@@ -819,7 +820,7 @@ async def fetch_discogs(release_id: str):
 
 @app.get("/api/health")
 def health():
-    return {"status": "ok"}
+    return {"status": "ok", "dev": bool(os.environ.get("SN_DEV"))}
 
 
 # ── Routes: Records ───────────────────────────────────────────────────────────

--- a/app.py
+++ b/app.py
@@ -820,7 +820,7 @@ async def fetch_discogs(release_id: str):
 
 @app.get("/api/health")
 def health():
-    return {"status": "ok", "dev": bool(os.environ.get("SN_DEV"))}
+    return {"status": "ok", "dev": os.environ.get("SN_DEV", "").lower() == "true"}
 
 
 # ── Routes: Records ───────────────────────────────────────────────────────────

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,3 +1,5 @@
 services:
   sleevenotes:
     build: .
+    environment:
+      - SN_DEV=true

--- a/static/index.html
+++ b/static/index.html
@@ -88,6 +88,22 @@
     gap: 0.75rem;
   }
 
+  /* ── Dev banner ── */
+  #dev-banner {
+    display: none;
+    position: sticky;
+    top: 56px;
+    z-index: 100;
+    background: #B45309;
+    color: #FEF3C7;
+    text-align: center;
+    padding: 0.375rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+  }
+
   /* ── Offline banner ── */
   #offline-banner {
     display: none;
@@ -918,6 +934,7 @@
   </div>
 </header>
 
+<div id="dev-banner">DEV ENVIRONMENT</div>
 <div id="offline-banner">Offline — read-only mode</div>
 
 <div class="stats-bar" id="stats-bar">
@@ -1590,6 +1607,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   await initPendingQueue();
   updateOnlineState();
   probeHealth();
+  fetch('/api/health').then(r => r.json()).then(d => {
+    if (d.dev) document.getElementById('dev-banner').style.display = 'block';
+  }).catch(() => {});
   await loadSettings();
   loadRecords();
   loadWishlist();


### PR DESCRIPTION
## Summary
- Adds a persistent amber banner reading **DEV ENVIRONMENT** shown only on local dev builds
- `compose.override.yml` sets `SN_DEV=true` — live server has no such variable so is unaffected
- `/api/health` now returns `{"status": "ok", "dev": true/false}` — checked once on page load

## Test plan
- [ ] `docker compose up --build` locally — DEV ENVIRONMENT banner appears below the header
- [ ] Banner is not shown on the live server (no `SN_DEV` env var set)
- [ ] Offline and reachability banners still appear correctly beneath it

Relates to #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)