### PR TITLE
fix: change default record sort from instance_id to id

### DIFF
--- a/app.py
+++ b/app.py
@@ -830,7 +830,7 @@ def list_records():
     try:
         with get_db() as conn:
             rows = conn.execute(
-                "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY CAST(instance_id AS INTEGER), id"
+                "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY id"
             ).fetchall()
         return [row_to_dict(r) for r in rows]
     except sqlite3.OperationalError:
@@ -1105,7 +1105,7 @@ _EXPORT_SN_EXTRAS = ("id", "instance_id", "is_new", "cover_file")
 async def export_csv():
     with get_db() as conn:
         db_rows = conn.execute(
-            "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY CAST(instance_id AS INTEGER), id"
+            "SELECT * FROM records WHERE deleted_at IS NULL ORDER BY id"
         ).fetchall()
         settings_rows = conn.execute("SELECT key, value FROM settings").fetchall()
     settings = {r["key"]: r["value"] for r in settings_rows}


### PR DESCRIPTION
## Summary
- Default record ordering changed from `CAST(instance_id AS INTEGER) ASC` to `id ASC`
- Fixes new records floating to the top — `NULL` instance_id sorted before all integers in SQLite ASC order
- `id` is stable, never NULL, and reflects the order records were added to SleeveNotes

## Test plan
- [ ] Add a new record without syncing to Discogs — confirm it appears at the bottom of the list, not the top
- [ ] Confirm existing records appear in the same relative order as before (will match for collections imported via bulk Discogs sync)

Relates to #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)