### PR TITLE
fix: correct group-by-artist header row column structure

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2077,7 +2077,7 @@ function renderTable() {
   for (const r of rows) {
     if (grouped && r.artist !== lastArtist) {
       lastArtist = r.artist;
-      bodyHtml += `<tr class="group-header"><td colspan="15">${esc(displayArtist(r.artist))}</td></tr>`;
+      bodyHtml += `<tr class="group-header"><td colspan="3">${esc(displayArtist(r.artist))}</td><td class="col-sm"></td><td class="col-sm"></td><td class="col-sm"></td><td class="col-md"></td><td class="col-md"></td><td class="col-sm"></td><td class="col-md"></td><td class="col-md"></td><td class="col-md"></td></tr>`;
     }
     bodyHtml += rowHtml(r);
   }


### PR DESCRIPTION
Closes #61
Closes #62

## Summary

The group-by-artist header row was rendered as a single `<td colspan="15">`, but the table only has 12 columns. This caused two related issues:

- **Desktop (#62):** The inflated colspan caused `table-layout: fixed` to allocate phantom columns, leaving dead whitespace to the right of the table.
- **Mobile (#61):** When combined with the hidden `col-sm`/`col-md` columns, the single spanning cell confused the browser's fixed-layout width distribution, collapsing the artist and title columns to tiny widths.

The fix gives the group header row the same column structure as the data rows: the artist name spans the 3 always-visible columns (cover, artist, title), with correctly classed empty cells for the remaining columns. These hide on mobile exactly as data row cells do, removing all ambiguity from the layout algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)