### PR TITLE
fix: use apiFetch for record save and Discogs sync preview

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -2453,7 +2453,7 @@ async function saveRecord() {
   try {
     const url = editingId ? `/api/records/${editingId}` : '/api/records';
     const method = editingId ? 'PUT' : 'POST';
-    const r = await fetch(url, {
+    const r = await apiFetch(url, {
       method,
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload),
@@ -2663,7 +2663,7 @@ async function previewSync(recordId = null) {
   openSyncModal();
   try {
     const url = recordId ? `/api/collection/preview?record_id=${recordId}` : '/api/collection/preview';
-    const resp = await fetch(url);
+    const resp = await apiFetch(url);
     if (!resp.ok) throw new Error((await resp.json()).detail || resp.status);
     diffData = await resp.json();
     renderSyncPreview(diffData);


### PR DESCRIPTION
Closes #64

Two calls were using raw `fetch` instead of `apiFetch`, so the `X-API-Key` header was not sent when authentication is enabled — causing 401s on record save and Discogs sync preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)