### PR TITLE
feat: data export and backup restore (#57)

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import re
 import sqlite3
 import asyncio
 import logging
+import zipfile
 import httpx
 from pathlib import Path
 from datetime import datetime
@@ -1211,6 +1212,98 @@ async def export_csv():
         media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=sleevenotes_export.csv"},
     )
+
+
+@app.get("/api/export/db")
+def export_db():
+    buf = io.BytesIO()
+    with get_db() as conn:
+        sql = "\n".join(conn.iterdump())
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("sleevenotes.sql", sql)
+    buf.seek(0)
+    return StreamingResponse(buf, media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=sleevenotes_db.zip"})
+
+
+@app.get("/api/export/images")
+def export_images():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in sorted(IMAGES_DIR.iterdir()):
+            if f.is_file():
+                zf.write(f, f.name)
+    buf.seek(0)
+    return StreamingResponse(buf, media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=sleevenotes_images.zip"})
+
+
+@app.get("/api/export/all")
+def export_all():
+    buf = io.BytesIO()
+    with get_db() as conn:
+        sql = "\n".join(conn.iterdump())
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("sleevenotes.sql", sql)
+        for f in sorted(IMAGES_DIR.iterdir()):
+            if f.is_file():
+                zf.write(f, f.name)
+    buf.seek(0)
+    return StreamingResponse(buf, media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=sleevenotes_backup.zip"})
+
+
+@app.post("/api/import/db")
+async def import_db(file: UploadFile = File(...)):
+    global _cached_api_key
+    content = await file.read()
+    with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+        sql_names = [n for n in zf.namelist() if n.endswith(".sql")]
+        if not sql_names:
+            raise HTTPException(status_code=400, detail="No .sql file found in zip")
+        sql = zf.read(sql_names[0]).decode("utf-8")
+    DB_PATH.unlink(missing_ok=True)
+    with get_db() as conn:
+        conn.executescript(sql)
+    _cached_api_key = None
+    return {"ok": True}
+
+
+@app.post("/api/import/images")
+async def import_images_zip(file: UploadFile = File(...)):
+    content = await file.read()
+    IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+        for name in zf.namelist():
+            if name and "/" not in name and not name.endswith(".sql"):
+                (IMAGES_DIR / name).write_bytes(zf.read(name))
+                count += 1
+    return {"imported": count}
+
+
+@app.post("/api/import/all")
+async def import_all(file: UploadFile = File(...)):
+    global _cached_api_key
+    content = await file.read()
+    with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
+        names = zf.namelist()
+        sql_names = [n for n in names if n.endswith(".sql")]
+        if not sql_names:
+            raise HTTPException(status_code=400, detail="No .sql file found in zip")
+        sql = zf.read(sql_names[0]).decode("utf-8")
+        DB_PATH.unlink(missing_ok=True)
+        with get_db() as conn:
+            conn.executescript(sql)
+        _cached_api_key = None
+        IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+        img_count = 0
+        for name in names:
+            if name and "/" not in name and not name.endswith(".sql"):
+                (IMAGES_DIR / name).write_bytes(zf.read(name))
+                img_count += 1
+    return {"ok": True, "images": img_count}
+
 
 # ── Routes: Wishlist ─────────────────────────────────────────────────────────
 

--- a/static/index.html
+++ b/static/index.html
@@ -1344,9 +1344,18 @@
 
       <div style="border:1px solid var(--border);border-radius:var(--radius);padding:1rem;display:flex;flex-direction:column;gap:0.75rem;">
         <div style="font-family:var(--font-mono);font-size:11px;text-transform:uppercase;letter-spacing:0.07em;color:var(--ink-light);font-weight:500">Data</div>
+        <div style="font-size:12px;font-weight:500;color:var(--ink)">Import</div>
         <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
-          <label id="btn-import-csv" class="btn btn-secondary btn-sm" style="cursor:pointer">Import from CSV<input id="input-import-csv" type="file" accept=".csv" style="display:none" onchange="importCsv(this)"></label>
+          <label id="btn-import-csv" class="btn btn-secondary btn-sm" style="cursor:pointer">Import from CSV…<input id="input-import-csv" type="file" accept=".csv" style="display:none" onchange="importCsv(this)"></label>
+        </div>
+        <div style="font-size:12px;color:var(--ink-light)">To restore database or image backups, see <strong>Restore from Backup</strong> in the Danger Zone below.</div>
+        <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
+        <div style="font-size:12px;font-weight:500;color:var(--ink)">Export</div>
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
           <button class="btn btn-secondary btn-sm" onclick="doExport()">Export to CSV</button>
+          <button id="btn-export-db" class="btn btn-secondary btn-sm" onclick="doExportDb(this)">Export Database</button>
+          <button id="btn-export-images" class="btn btn-secondary btn-sm" onclick="doExportImages(this)">Export Images</button>
+          <button id="btn-export-all" class="btn btn-secondary btn-sm" onclick="doExportAll(this)">Export All</button>
         </div>
       </div>
 
@@ -1376,6 +1385,31 @@
           <button class="btn btn-danger" id="change-access-key-btn" onclick="doChangeAccessKey()" style="align-self:flex-start">
             Change Key
           </button>
+        </div>
+
+        <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
+
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
+          <div>
+            <div style="font-size:13px;font-weight:500;color:var(--ink)">Restore from Backup</div>
+            <div style="font-size:12px;color:var(--ink-light);margin-top:2px">Restore database, images, or both from a backup zip. Replaces existing data. Cannot be undone.</div>
+          </div>
+          <label class="toggle" style="flex-shrink:0" title="Enable to unlock">
+            <input type="checkbox" id="import-db-safety-toggle" onchange="onImportToggle()">
+            <div class="toggle-track"></div>
+            <div class="toggle-thumb"></div>
+          </label>
+        </div>
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+          <label id="import-db-btn" class="btn btn-danger btn-sm" disabled style="opacity:0.4;cursor:not-allowed">
+            Import Database…<input id="input-import-db" type="file" accept=".zip" style="display:none" onchange="doImportDb(this)">
+          </label>
+          <label id="import-images-btn" class="btn btn-danger btn-sm" disabled style="opacity:0.4;cursor:not-allowed">
+            Import Images…<input id="input-import-images" type="file" accept=".zip" style="display:none" onchange="doImportImages(this)">
+          </label>
+          <label id="import-all-btn" class="btn btn-danger btn-sm" disabled style="opacity:0.4;cursor:not-allowed">
+            Import All…<input id="input-import-all" type="file" accept=".zip" style="display:none" onchange="doImportAll(this)">
+          </label>
         </div>
 
         <div style="height:1px;background:var(--border);margin:0.25rem 0"></div>
@@ -2541,8 +2575,103 @@ async function importCsv(input) {
   }
 }
 
-function doExport() {
-  window.location.href = '/api/export';
+async function doExportDownload(url, filename, btn) {
+  const origText = btn ? btn.textContent : null;
+  if (btn) { btn.disabled = true; btn.textContent = 'Exporting…'; }
+  try {
+    const r = await apiFetch(url);
+    if (!r.ok) throw new Error();
+    const blob = await r.blob();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  } catch {
+    toast('Export failed', 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = origText; }
+  }
+}
+
+function doExport() { doExportDownload('/api/export', 'sleevenotes_export.csv'); }
+
+async function doExportDb(btn)     { await doExportDownload('/api/export/db',     'sleevenotes_db.zip',        btn); }
+async function doExportImages(btn) { await doExportDownload('/api/export/images', 'sleevenotes_images.zip',    btn); }
+async function doExportAll(btn)    { await doExportDownload('/api/export/all',    'sleevenotes_backup.zip',    btn); }
+
+function onImportToggle() {
+  const on = document.getElementById('import-db-safety-toggle').checked;
+  for (const id of ['import-db-btn', 'import-images-btn', 'import-all-btn']) {
+    const btn = document.getElementById(id);
+    btn.disabled = !on;
+    btn.style.opacity = on ? '1' : '0.4';
+    btn.style.cursor = on ? 'pointer' : 'not-allowed';
+  }
+}
+
+function onImportDbToggle()     { onImportToggle(); }
+function onImportImagesToggle() { onImportToggle(); }
+function onImportAllToggle()    { onImportToggle(); }
+
+async function doImportDb(input) {
+  const file = input.files[0];
+  if (!file) return;
+  input.value = '';
+  if (!confirm(`Replace the entire database with "${file.name}"? This cannot be undone.`)) return;
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    const r = await apiFetch('/api/import/db', { method: 'POST', body: fd });
+    if (!r.ok) { const e = await r.json().catch(() => ({})); toast(e.detail || 'Import failed', 'error'); return; }
+    toast('Database imported — reloading…');
+    setTimeout(() => location.reload(), 1200);
+  } catch { toast('Import failed', 'error'); }
+}
+
+async function doImportImages(input) {
+  const file = input.files[0];
+  if (!file) return;
+  input.value = '';
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    const r = await apiFetch('/api/import/images', { method: 'POST', body: fd });
+    if (!r.ok) { const e = await r.json().catch(() => ({})); toast(e.detail || 'Import failed', 'error'); return; }
+    const d = await r.json();
+    toast(`Imported ${d.imported} image${d.imported !== 1 ? 's' : ''}`);
+    loadRecords();
+  } catch { toast('Import failed', 'error'); }
+}
+
+async function doImportAll(input) {
+  const file = input.files[0];
+  if (!file) return;
+  input.value = '';
+  if (!confirm(`Replace the entire database and images with "${file.name}"? This cannot be undone.`)) return;
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    const r = await apiFetch('/api/import/all', { method: 'POST', body: fd });
+    if (!r.ok) { const e = await r.json().catch(() => ({})); toast(e.detail || 'Import failed', 'error'); return; }
+    toast('Backup restored — reloading…');
+    setTimeout(() => location.reload(), 1200);
+  } catch { toast('Import failed', 'error'); }
+}
+
+async function doImportAllDirect(input) {
+  const file = input.files[0];
+  if (!file) return;
+  input.value = '';
+  if (!confirm(`Restore from "${file.name}"? This will replace your current database and images.`)) return;
+  const fd = new FormData();
+  fd.append('file', file);
+  try {
+    const r = await apiFetch('/api/import/all', { method: 'POST', body: fd });
+    if (!r.ok) { const e = await r.json().catch(() => ({})); toast(e.detail || 'Import failed', 'error'); return; }
+    toast('Backup restored — reloading…');
+    setTimeout(() => location.reload(), 1200);
+  } catch { toast('Import failed', 'error'); }
 }
 
 // ── Discogs Sync ──────────────────────────────────────────────────────────────
@@ -2911,6 +3040,8 @@ function openSettings() {
   onFactoryResetToggle();
   document.getElementById('clear-images-safety-toggle').checked = false;
   onClearImagesToggle();
+  document.getElementById('import-db-safety-toggle').checked = false;
+  onImportToggle();
   buildFetchRanges();
   document.getElementById('fetch-progress').classList.add('hidden');
   // Reset mapping section then fetch (or prompt if no username yet)
@@ -3542,6 +3673,11 @@ function emptyState() {
       <div class="empty-icon">♪</div>
       <div class="empty-text">Your collection is empty</div>
       <div class="empty-sub">Use <strong>Add Record</strong> or <strong>Import</strong> to get started</div>
+      <div class="empty-sub" style="margin-top:0.75rem">
+        <label class="btn btn-secondary btn-sm" style="cursor:pointer">
+          Restore from backup…<input type="file" accept=".zip" style="display:none" onchange="doImportAllDirect(this)">
+        </label>
+      </div>
     </div>`;
   }
   return `<div class="empty">


### PR DESCRIPTION
## Summary

- Adds three new exports to the Data section: **Export Database** (SQL dump as `.zip`), **Export Images** (cover cache as `.zip`), **Export All** (combined backup zip `sleevenotes_backup.zip`)
- Slow exports (Database, Images, All) show an **Exporting…** loading state on the button while the server builds the zip
- Data section split into **Import** and **Export** subsections; Import CSV stays here with a note pointing to Danger Zone for destructive restores
- Adds a **Restore from Backup** section in the Danger Zone: one safety toggle unlocks three side-by-side buttons — Import Database, Import Images, Import All — each accepting the corresponding zip format
- Empty collection state gains a **Restore from backup…** shortcut that bypasses the toggle (suitable since there's nothing to overwrite)

## Test plan

- [ ] Export to CSV, Export Database, Export Images, Export All all download the correct files
- [ ] Export Database / Images / All show "Exporting…" while in flight and restore label on completion
- [ ] Import Database restores DB, reloads page
- [ ] Import Images restores cover files
- [ ] Import All restores DB + images, reloads page
- [ ] Restore from Backup toggle in Danger Zone resets to off on modal open
- [ ] Empty state "Restore from backup…" button works end-to-end
- [ ] Import CSV still works from Data section

🤖 Generated with [Claude Code](https://claude.com/claude-code)