### PR TITLE
docs: remove stale FR todo and version speculation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,7 @@ Always create a feature branch before making any code or config changes. Never c
 
 Docker images are published to `ghcr.io/sidtheturtle/sleevenotes` on version tag pushes only — main branch pushes do not trigger a build.
 
-**Version strategy:** `vMAJOR.MINOR.PATCH` — currently on `v1.x.y`, approaching `v1.9.0`. New features increment minor, bug fixes increment patch.
-
-**Remaining open FR:** #52 — Pagination (table default 50 rows, tiles default 25, page size configurable in settings).
+**Version strategy:** `vMAJOR.MINOR.PATCH` — currently on `v1.x.y`. New features increment minor, bug fixes increment patch.
 
 **To cut a release:** `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..." --target main`
 


### PR DESCRIPTION
- Removes the stale "Remaining open FR: #52" line (closed as won't implement)
- Removes "approaching v1.9.0" — no speculative versioning in the doc

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)