### PR TITLE
fix: set fixed width on wishlist table thumbnail column

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3388,7 +3388,7 @@ function renderWishlist() {
 
   const rows = items.map(w => `
     <tr class="${w.fulfilled ? 'wishlist-row-fulfilled' : ''} data-row" style="cursor:pointer" onclick="openWishlistDetail(${w.id})">
-      <td>${w.pending
+      <td class="col-cover">${w.pending
         ? (w.thumb ? `<img class="cover-thumb" src="${esc(w.thumb)}" alt="" loading="lazy">` : `<div class="cover-placeholder">⏳</div>`)
         : (w.cover_file ? `<img class="cover-thumb" src="/images/${esc(w.cover_file)}" alt="" loading="lazy">` : `<div class="cover-placeholder">♡</div>`)}</td>
       <td class="overflow" title="${esc(w.artist)}">${esc(w.artist)}</td>
@@ -3403,7 +3403,7 @@ function renderWishlist() {
       <table>
         <thead>
           <tr>
-            <th></th>
+            <th class="col-cover"></th>
             ${th('artist', 'Artist')}
             ${th('title', 'Title')}
             ${th('year', 'Year', 'col-sm')}


### PR DESCRIPTION
Closes #72

The wishlist table's thumbnail `<th>` and `<td>` were missing the `col-cover` class (64px fixed width), causing the column to expand and crowd/truncate other columns. Applies the same fixed width already used by the collection table.