### PR TITLE
fix: make valuation field readonly in edit form

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1151,7 +1151,7 @@
           <label class="form-label">Valuation — lowest listing</label>
           <div class="input-prefix-wrap">
             <span class="input-prefix currency-prefix">£</span>
-            <input class="form-control" type="number" step="0.01" min="0" id="f-valuation" value="0.00">
+            <input class="form-control" type="number" step="0.01" min="0" id="f-valuation" value="0.00" readonly>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- `#f-valuation` in the add/edit form now has `readonly`, matching Artist, Title, Label, Cat No., Year, and Format
- Valuation is Discogs-sourced and overwritten on every Sync Metadata / refresh — allowing manual edits was misleading

Closes #84

## Test plan

- [ ] Open any record in edit mode — Valuation field is displayed but cannot be typed into
- [ ] Sync Metadata still updates the displayed value correctly after fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)