### PR TITLE
Add prev/next navigation and set-cover to the lightbox (#78)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -943,6 +943,56 @@
     border-radius: 4px;
     box-shadow: 0 8px 40px rgba(0,0,0,0.6);
   }
+  #lightbox-inner {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .lightbox-arrow {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(0,0,0,0.55);
+    color: #fff;
+    border: none;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    font-size: 24px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+  }
+  .lightbox-arrow:hover { background: rgba(0,0,0,0.85); }
+  .lightbox-meta .btn {
+    background: #fff;
+    color: #1a1a1a;
+    border: 1px solid #fff;
+  }
+  .lightbox-meta .btn:hover:not(:disabled) { background: #e8e8e8; }
+  .lightbox-meta .btn:disabled { opacity: 1; background: rgba(255,255,255,0.35); color: #fff; border-color: transparent; }
+  .lightbox-arrow.prev { left: 16px; }
+  .lightbox-arrow.next { right: 16px; }
+  .lightbox-meta {
+    position: absolute;
+    left: 50%;
+    bottom: 12px;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: #fff;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    cursor: default;
+    background: rgba(0,0,0,0.6);
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    white-space: nowrap;
+  }
   .detail-cover-clickable { cursor: zoom-in; }
   /* ── Auth screen ── */
   #auth-screen {
@@ -1544,7 +1594,7 @@
 
 <!-- ── Lightbox ── -->
 <div id="lightbox" onclick="closeLightbox()">
-  <img id="lightbox-img" src="" alt="cover">
+  <div id="lightbox-inner"></div>
 </div>
 
 <script>
@@ -2332,7 +2382,7 @@ function setupCarousel(recordId, images, currentCover) {
     wrap.innerHTML = `
       <div class="carousel-wrap">
         <div class="carousel-img-wrap">
-          <img src="/images/${esc(img.filename)}" alt="cover ${idx+1}" class="detail-cover-clickable" onclick="openLightbox('/images/${esc(img.filename)}')" style="cursor:zoom-in">
+          <img src="/images/${esc(img.filename)}" alt="cover ${idx+1}" class="detail-cover-clickable" onclick="carouselLightbox()" style="cursor:zoom-in">
           ${images.length > 1 ? `
             <button class="carousel-arrow prev" onclick="carouselStep(-1)">&#8249;</button>
             <button class="carousel-arrow next" onclick="carouselStep(1)">&#8250;</button>` : ''}
@@ -2351,6 +2401,8 @@ function setupCarousel(recordId, images, currentCover) {
     idx = (idx + dir + images.length) % images.length;
     render();
   };
+
+  window.carouselLightbox = () => openLightbox(images, idx, recordId);
 
   render();
 }
@@ -3806,10 +3858,65 @@ function setField(id, v) { const el = document.getElementById(id); if (el) el.va
 function openModal(id) { document.getElementById(id).classList.add('open'); }
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }
 
-function openLightbox(src) {
-  document.getElementById('lightbox-img').src = src;
+// Lightbox: accepts either a bare URL string (single image, no chrome) or an
+// array of image objects [{filename, is_cover}] + start index + record id.
+let lightboxImages = [];
+let lightboxIdx = 0;
+let lightboxRecordId = null;
+
+function openLightbox(arg, idx = 0, recordId = null) {
+  if (typeof arg === 'string') {
+    lightboxImages = [{ src: arg }];
+    lightboxIdx = 0;
+    lightboxRecordId = null;
+  } else {
+    lightboxImages = (arg || []).map(i => ({
+      src: `/images/${i.filename}`, filename: i.filename, is_cover: i.is_cover,
+    }));
+    lightboxIdx = idx;
+    lightboxRecordId = recordId;
+  }
+  renderLightbox();
   document.getElementById('lightbox').classList.add('open');
 }
+
+function renderLightbox() {
+  const imgs = lightboxImages;
+  const cur = imgs[lightboxIdx];
+  if (!cur) return;
+  const multi = imgs.length > 1;
+  let coverBtn = '';
+  if (lightboxRecordId && multi) {
+    const anyFlagged = imgs.some(i => i.is_cover === 1);
+    const isCover = anyFlagged ? cur.is_cover === 1 : lightboxIdx === 0;
+    coverBtn = `<button class="btn btn-secondary btn-sm" onclick="event.stopPropagation(); lightboxSetCover()"
+      ${isCover ? 'disabled title="Already the cover"' : ''}>Use as Cover</button>`;
+  }
+  document.getElementById('lightbox-inner').innerHTML = `
+    <img id="lightbox-img" src="${esc(cur.src)}" alt="cover">
+    ${multi ? `
+      <button class="lightbox-arrow prev" onclick="event.stopPropagation(); lightboxStep(-1)">&#8249;</button>
+      <button class="lightbox-arrow next" onclick="event.stopPropagation(); lightboxStep(1)">&#8250;</button>
+      <div class="lightbox-meta" onclick="event.stopPropagation()">
+        <span>${lightboxIdx + 1} / ${imgs.length}</span>
+        ${coverBtn}
+      </div>` : ''}`;
+}
+
+function lightboxStep(dir) {
+  if (lightboxImages.length < 2) return;
+  lightboxIdx = (lightboxIdx + dir + lightboxImages.length) % lightboxImages.length;
+  renderLightbox();
+}
+
+async function lightboxSetCover() {
+  const cur = lightboxImages[lightboxIdx];
+  if (!cur || !lightboxRecordId) return;
+  await setCover(lightboxRecordId, cur.filename);
+  lightboxImages = lightboxImages.map((i, n) => ({ ...i, is_cover: n === lightboxIdx ? 1 : 0 }));
+  renderLightbox();
+}
+
 function closeLightbox() { document.getElementById('lightbox').classList.remove('open'); }
 
 function toast(msg, type = '') {
@@ -3899,7 +4006,12 @@ async function apiFetch(url, opts = {}) {
 }
 
 window.addEventListener('online', () => { updateOnlineState(); probeHealth(); });
-document.addEventListener('keydown', e => { if (e.key === 'Escape') closeLightbox(); });
+document.addEventListener('keydown', e => {
+  if (!document.getElementById('lightbox').classList.contains('open')) return;
+  if (e.key === 'Escape') closeLightbox();
+  else if (e.key === 'ArrowLeft') lightboxStep(-1);
+  else if (e.key === 'ArrowRight') lightboxStep(1);
+});
 window.addEventListener('offline', () => {
   clearTimeout(_reachabilityPollTimer);
   _reachabilityPollTimer = null;


### PR DESCRIPTION
Closes #78

## What

The image lightbox now supports browsing all images for a release, not just the one clicked.

- **Prev/next arrows** (`‹` / `›`) and an `n / total` counter when a release has multiple images
- **"Use as Cover" button** in the lightbox, mirroring the detail-modal carousel (disabled when the shown image is already the cover)
- **Arrow keys** step through images; Escape still closes
- Meta bar sits on a rounded dark pill anchored to the image; opaque "Use as Cover" button for legibility on the dark backdrop

Single-image callers (plain detail cover, wishlist cover) pass a bare URL string and get the chrome-free lightbox exactly as before.

## Scope

Frontend only (`static/index.html`) — no backend change; `/api/records/{id}/set-cover` already exists.

## Testing

- `pytest` — 65/65 pass (API suite; unaffected by this change)
- Manual: multi-image record → arrows, keyboard nav, counter, set-cover (toast + thumbnail update); single-image + wishlist covers open plain; backdrop/Escape close

🤖 Generated with [Claude Code](https://claude.com/claude-code)