### PR TITLE
feat: persist collection/wishlist section across page refresh (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,10 +249,10 @@ _lastSearchResults    // array — last wishlist search results; used by addToWi
 apiKey            // string — loaded from sessionStorage on auth; injected by apiFetch()
 ```
 
-Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within **both** sections. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. Only `'table'`/`'tile'` are saved to localStorage — app always opens to collection.
+Two-level nav: top-level **Collection / Wishlist** switch (always visible), with **Table / Tile** as sub-options within **both** sections. `setSection(s)` handles top-level nav; `setView(v)` handles sub-views. `'table'`/`'tile'` are saved to localStorage; the active section (collection/wishlist) is saved to **sessionStorage** (`sn_section`) so a page refresh keeps your place but a new tab/window opens to collection.
 
 ### localStorage persistence
-All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view` (table/tile only — wishlist never persisted as startup view), `showTags`, `groupByArtist`, `showFulfilled`. `showValuations` is DB-backed via the `settings` table, not localStorage.
+All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers (prefixed `sn_`). `restoreLocalState()` runs on `DOMContentLoaded` before any data fetch. Persisted keys: `view` (table/tile), `showTags`, `groupByArtist`, `showFulfilled`. `showValuations` is DB-backed via the `settings` table, not localStorage. The active section is persisted separately in sessionStorage via `ssGet` / `ssSet` (`sn_section`) — `restoreLocalState()` reads it to restore collection/wishlist across a refresh.
 
 ### Key functions
 

--- a/static/index.html
+++ b/static/index.html
@@ -1635,6 +1635,15 @@ function lsSet(key, val) {
   try { localStorage.setItem('sn_' + key, JSON.stringify(val)); } catch {}
 }
 
+// ── sessionStorage helpers (survive refresh, not tab close) ─────────────────
+function ssGet(key, fallback) {
+  try { const v = sessionStorage.getItem('sn_' + key); return v !== null ? JSON.parse(v) : fallback; }
+  catch { return fallback; }
+}
+function ssSet(key, val) {
+  try { sessionStorage.setItem('sn_' + key, JSON.stringify(val)); } catch {}
+}
+
 // ── Auth ────────────────────────────────────────────────────────────────────
 function showAuthScreen(mode) {
   _authMode = mode;
@@ -1889,9 +1898,11 @@ function restoreLocalState() {
   currentView = lsGet('view', 'table');
   document.getElementById('btn-table').classList.toggle('active', currentView === 'table');
   document.getElementById('btn-tile').classList.toggle('active', currentView === 'tile');
-  document.getElementById('btn-collection').classList.add('active');
-  document.getElementById('btn-wishlist-nav').classList.remove('active');
-  applyToolbarSwitches('collection');
+
+  currentSection = ssGet('section', 'collection') === 'wishlist' ? 'wishlist' : 'collection';
+  document.getElementById('btn-collection').classList.toggle('active', currentSection === 'collection');
+  document.getElementById('btn-wishlist-nav').classList.toggle('active', currentSection === 'wishlist');
+  applyToolbarSwitches(currentSection);
 
   showTags = lsGet('showTags', false);
   document.getElementById('show-tags').checked = showTags;
@@ -2097,6 +2108,7 @@ function setView(v) {
 
 function setSection(section) {
   currentSection = section;
+  ssSet('section', section);
   selectedTileId = null;
   document.getElementById('search').value = '';
   document.getElementById('btn-collection').classList.toggle('active', section === 'collection');


### PR DESCRIPTION
## What

The active section (Collection / Wishlist) now persists across a page refresh via `sessionStorage` (`sn_section`).

Refreshing while waiting on queued Discogs actions previously always dropped you back on Collection, so you'd have to click Wishlist again.

## How

- Added `ssGet` / `ssSet` sessionStorage helpers alongside the existing `ls*` ones
- `setSection()` writes the section to sessionStorage
- `restoreLocalState()` reads it back on load and restores `currentSection`, nav button state, and toolbar switches
- Used `sessionStorage` deliberately: a refresh keeps your place, but a fresh tab/window still opens to Collection

Existing init already calls both `loadRecords()` and `loadWishlist()` and `renderView()` routes on `currentSection`, so no init-ordering changes were needed.

Docs updated in CLAUDE.md.

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)