### PR TITLE
fix: wishlist tiles show overlay on first tap like collection tiles

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -3475,7 +3475,7 @@ function renderWishlistTiles() {
   }
 
   el.innerHTML = `<div class="tile-grid">${items.map(w => `
-    <div class="tile" onclick="openWishlistDetail(${w.id})">
+    <div class="tile${selectedTileId === w.id ? ' active' : ''}" data-id="${w.id}" onclick="wishlistTileClick(event,${w.id})">
       ${w.pending
         ? (w.thumb ? `<img class="tile-img" src="${esc(w.thumb)}" alt="${esc(displayArtist(w.artist))} - ${esc(w.title)}" loading="lazy">` : `<div class="tile-placeholder">⏳</div>`)
         : (w.cover_file ? `<img class="tile-img" src="${imgSrc(w.cover_file, 'm')}" alt="${esc(displayArtist(w.artist))} - ${esc(w.title)}" loading="lazy" onerror="${imgFallback(esc(w.cover_file))}">` : `<div class="tile-placeholder">♡</div>`)}
@@ -3484,8 +3484,20 @@ function renderWishlistTiles() {
         <div class="tile-overlay-artist">${esc(displayArtist(w.artist))}</div>
         <div class="tile-overlay-title">${esc(w.title)}</div>
         ${w.year ? `<div style="font-size:11px;color:var(--cream);opacity:0.8;font-family:var(--font-mono);margin-top:0.15rem">${w.year}</div>` : ''}
+        <button class="btn btn-primary" style="font-size:16px;padding:0.6rem 2rem;margin-top:0.25rem" onclick="openWishlistDetail(${w.id})">View</button>
       </div>
     </div>`).join('')}</div>`;
+}
+
+// Mirrors tileClick() for the collection view — first tap activates the tile
+// and shows the overlay; the overlay's View button opens the detail modal.
+function wishlistTileClick(e, id) {
+  if (e.target.closest('button')) return;
+  e.stopPropagation();
+  selectedTileId = selectedTileId === id ? null : id;
+  document.querySelectorAll('.tile').forEach(t => {
+    t.classList.toggle('active', Number(t.dataset.id) === selectedTileId);
+  });
 }
 
 function renderWishlist() {


### PR DESCRIPTION
## What

Wishlist tile view opened the detail modal on a single click, unlike collection tiles which activate the tile and reveal an overlay with a **View** button first.

`renderWishlistTiles()` now uses the same active-tile pattern as `renderTiles()`:

- Tile `<div>` carries `data-id` and calls a new `wishlistTileClick(event, id)` (mirrors `tileClick()`) instead of `openWishlistDetail(id)` directly.
- `wishlistTileClick()` toggles `selectedTileId` / the `.tile.active` class in place; reuses the existing global outside-click handler (view-based, so it already covers wishlist) and is negative-id safe for pending items.
- The overlay gains a **View** button that calls `openWishlistDetail(w.id)`; the `e.target.closest('button')` guard lets that click through.

## Test

Behaviour change is frontend-only. Layer 1 (backend) tests unaffected. The Layer 2 smoke suite referenced in the issue is not in the repo, so there is nothing to update there.

Verified in the running container at :2026 — first tap shows the overlay, View opens the detail modal.

Closes #87