### PR TITLE
fix: pin Compose project name to sleevenotes (#88)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,5 @@
+name: sleevenotes
+
 services:
   sleevenotes:
     image: ghcr.io/sidtheturtle/sleevenotes:latest


### PR DESCRIPTION
## Problem

`compose.yml` has no top-level `name:` directive, so Docker Compose infers the project name from the deployment directory's basename (lowercased). When two compose stacks live in the same directory, they share one inferred project name, and `docker compose up --remove-orphans` on either stack treats the other's containers as orphans and deletes them — the SleeveNotes container included.

Closes #88

## Fix

Add `name: sleevenotes` to `compose.yml`. The project identity is now stable regardless of where the file is deployed. `container_name: sleevenotes` and the volume's `name: sleevenotes_data` are already pinned, so no data is touched.

## Migration — needs a release-notes line

Impact depends on the directory the user deployed from:

- **Deployed from a clone of the repo** (`SleeveNotes/` → normalises to `sleevenotes`): no-op, the inferred name already matched.
- **Deployed from a differently-named directory** (e.g. `~/docker/vinyl/`): project name changes on next `up`.
  - One-time container name conflict (`container_name` is pinned and the old container still carries the old project label). Resolve with `docker rm -f sleevenotes` then `docker compose up -d`. **No data loss** — the volume is re-attached by its explicit name.
  - **Cosmetic warning** on every `up` thereafter: *"volume sleevenotes_data was created by a different Compose project"*. The volume still works and the data is intact. To silence it, either:
    - declare the volume as `external: true` in your local `compose.yml`, **or**
    - create a fresh volume under the new project and copy the data across.

Suggested release-notes wording:

> **Breaking (only if you deploy from a directory not named `sleevenotes`):** the Compose project name is now pinned to `sleevenotes`. On first `up` after upgrading you may hit a container name conflict — run `docker rm -f sleevenotes && docker compose up -d`. Your data volume is preserved. You may then see a harmless "created by a different Compose project" warning; set `external: true` on the volume to silence it, or migrate the data to a new volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)