### PR TITLE
feat: site footer linking to the GitHub repo (#90)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -277,6 +277,21 @@
   /* ── Main content ── */
   main { padding: 1.5rem 2rem; }
 
+  /* ── Site footer ── */
+  .site-footer {
+    border-top: 1px solid var(--border);
+    padding: 1.25rem 2rem;
+    text-align: center;
+    font-size: 12px;
+    color: var(--ink-light);
+  }
+  .site-footer a {
+    color: var(--ink-mid);
+    text-decoration: none;
+    border-bottom: 1px solid var(--groove);
+  }
+  .site-footer a:hover { color: var(--ink); }
+
   /* ── Table view ── */
   .table-wrap { overflow-x: auto; background: var(--warm-white); border-radius: 6px; border: 1px solid var(--border); }
 
@@ -912,6 +927,7 @@
     .toolbar { padding: 0.75rem 1rem; gap: 0.5rem; }
     .search-wrap { flex: 1 1 100%; }
     main { padding: 1rem; }
+    .site-footer { padding: 1rem; }
     .form-grid { grid-template-columns: 1fr; }
     .detail-layout { grid-template-columns: 1fr; }
   }
@@ -1123,6 +1139,11 @@
 </div><!-- #sticky-top -->
 
 <main id="main-content"></main>
+
+<footer class="site-footer">
+  SleeveNotes — a personal vinyl collection manager ·
+  <a href="https://github.com/sidtheturtle/sleevenotes" target="_blank" rel="noopener">View on GitHub</a>
+</footer>
 
 <!-- ── Detail Modal (tile click) ── -->
 <div class="modal-backdrop" id="modal-detail">


### PR DESCRIPTION
Closes #90

Adds a static footer below the main content linking to the project repo.

- `<footer class="site-footer">` sits after `<main>`, outside `#sticky-top` so it scrolls with the page
- Link: "View on GitHub" → `https://github.com/sidtheturtle/sleevenotes` (`target="_blank" rel="noopener"`)
- `.site-footer` styled with theme tokens (`--border` top rule, `--ink-light` text, `--groove` link underline); tighter padding at the mobile breakpoint

Verified on the local port 2026 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)