### PR TITLE
feat: close modal dialogs on ESC (#92)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4141,6 +4141,13 @@ document.addEventListener('keydown', e => {
   else if (e.key === 'ArrowLeft') lightboxStep(-1);
   else if (e.key === 'ArrowRight') lightboxStep(1);
 });
+// ESC closes the topmost open modal (lightbox handled above takes priority)
+document.addEventListener('keydown', e => {
+  if (e.key !== 'Escape') return;
+  if (document.getElementById('lightbox').classList.contains('open')) return;
+  const open = document.querySelectorAll('.modal-backdrop.open');
+  if (open.length) closeModal(open[open.length - 1].id);
+});
 window.addEventListener('offline', () => {
   clearTimeout(_reachabilityPollTimer);
   _reachabilityPollTimer = null;


### PR DESCRIPTION
Closes #92

## What

Press <kbd>Esc</kbd> to close any open modal dialog (record detail, add/edit form, settings, sync preview, wishlist detail, wishlist search).

## How

New `document`-level `keydown` handler closes the topmost `.modal-backdrop.open`. The existing lightbox ESC handler runs first and takes priority when the lightbox is open, so ESC inside an image lightbox still just closes the lightbox.

Matches the behaviour of the existing ✕ header buttons (plain `closeModal`, no confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)