### PR TITLE
feat: barcode search for Add Record (#91, part 1 of 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 
 # Claude Code local config (contains personal paths/permissions)
 .claude/settings.local.json
+
+# Working specs (local only — not shipped)
+docs/fr-*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Per-release track data: `discogs_id`, `position`, `title`, `duration`, `type`, `
 | POST | `/api/records` | Create record |
 | PUT | `/api/records/{id}` | Update record |
 | DELETE | `/api/records/{id}` | Soft-delete record |
+| GET | `/api/discogs/search` | Search Discogs releases by `?barcode=` and/or `?q=` (400 if neither); `type=release`, `per_page=25` |
 | GET | `/api/discogs/{release_id}` | Fetch metadata + valuation from Discogs |
 | POST | `/api/records/{id}/refresh` | Re-fetch Discogs data for existing record |
 | GET | `/api/records/{id}/tracklist` | Get cached tracklist |
@@ -248,6 +249,7 @@ pendingQueue      // array — in-memory mirror of IDB wishlist_queue (new items
 pendingUpdates    // array — in-memory mirror of IDB wishlist_updates (edits queued offline)
 _serverWishlistItems  // array — last fetched server wishlist data; pendingUpdates applied on top
 _lastSearchResults    // array — last wishlist search results; used by addToWishlist for metadata
+_barcodePickCb        // fn|null — callback stored by openBarcodeSearch; fired with release id on Select
 apiKey            // string — loaded from sessionStorage on auth; injected by apiFetch()
 ```
 
@@ -288,6 +290,8 @@ All UI state is persisted via `lsGet(key, fallback)` / `lsSet(key, val)` helpers
 | `renderWishlistTiles()` | Build wishlist cover art grid sorted artist → year; pending items show corner Pending badge and ⏳ placeholder if no thumb |
 | `openWishlistSearchModal(prefill)` | Open master release search modal; blocked only when `!navigator.onLine`; shows offline info banner when server unreachable |
 | `doWishlistSearch()` | When server reachable: calls `/api/wishlist/search`. When offline: calls Discogs API directly (unauthenticated, 25 req/min). Stores results in `_lastSearchResults` |
+| `searchResultRow({thumb,title,meta,actionHtml})` | Shared search-result row markup; used by `doWishlistSearch` and `doBarcodeSearch` |
+| `openBarcodeSearch(onPick)` / `doBarcodeSearch()` | Open the barcode release picker (stores `onPick` in `_barcodePickCb`); search `/api/discogs/search?barcode=`. `barcodePick(id)` fires the callback and closes |
 | `addToWishlist(masterId)` | When online: POST to `/api/wishlist`. When offline: saves to IDB `wishlist_queue` via `saveToQueue()`, shows pending in list |
 | `deleteWishlistItem(id)` | DELETE item, reload wishlist |
 | `openWishlistDetail(id)` | Negative id → `openPendingWishlistDetail`. Otherwise: cover, metadata, fulfilled checkbox + notes textarea, Save (queues offline) + Delete (disabled offline) |
@@ -322,7 +326,8 @@ Always visible (no collapse toggle). Single nav row: `[Collection] [Wishlist]` p
 
 ### Modals
 - `modal-detail` — read-only record detail (tile click)
-- `modal-form` — add/edit form with Discogs lookup
+- `modal-form` — add/edit form with Discogs lookup. `#discogs-section` has a two-column "or" row: Release ID + Fetch on the left, Barcode + Search on the right. `openAdd()` shows + clears the barcode column; `openEdit()` hides it (`#barcode-col` + `#discogs-or-divider`) — barcode search is Add-only
+- `modal-barcode-search` — stacked over `modal-form`; generic callback-driven release picker (`openBarcodeSearch(onPick)` → `_barcodePickCb`). Searches `/api/discogs/search`, rows sorted year desc, "In collection" label when the `discogs_id` already exists. Select fires `onPick(releaseId)` and closes. The scanner FR (PR 2) reuses it unchanged
 - `modal-discogs-sync` — diff preview; shared between Discogs collection sync and CSV import. `syncSource` controls labels and available actions. "Discogs →" direction is hidden for CSV imports and for records where only core fields (artist, title, label, cat_no, year, format) differ
 - `modal-settings` — Display settings, Discogs config + field mapping, Data (import/export), Danger Zone. **Save stays open** (reload fields in-place); Close button dismisses.
 - `modal-wishlist-search` — Discogs master release search; results show Add/Queued/On wishlist/Fulfilled per item. Shows slate info banner when server unreachable (searching Discogs directly)

--- a/app.py
+++ b/app.py
@@ -909,6 +909,41 @@ async def collection_sync(payload: SyncPayload, background_tasks: BackgroundTask
 
 # ── Routes: Discogs ───────────────────────────────────────────────────────────
 
+@app.get("/api/discogs/search")
+async def search_releases(barcode: str | None = None, q: str | None = None):
+    """Search Discogs releases by barcode and/or free text. At least one required."""
+    if not barcode and not q:
+        raise HTTPException(status_code=400, detail="barcode or q required")
+    params: dict = {"type": "release", "per_page": 25}
+    if barcode:
+        params["barcode"] = barcode
+    if q:
+        params["q"] = q
+    hdrs = get_discogs_headers()
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await discogs_get(
+            client,
+            "https://api.discogs.com/database/search",
+            params=params,
+            headers=hdrs,
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail="Discogs search failed")
+    return [
+        {
+            "id": str(r.get("id")),
+            "title": r.get("title", ""),
+            "year": r.get("year"),
+            "country": r.get("country", ""),
+            "label": (r.get("label") or [""])[0],
+            "catno": r.get("catno", ""),
+            "format": ", ".join(r.get("format") or []),
+            "thumb": r.get("thumb", ""),
+        }
+        for r in resp.json().get("results", [])
+    ]
+
+
 @app.get("/api/discogs/{release_id}")
 async def fetch_discogs(release_id: str):
     rid = release_id.lstrip("r")

--- a/static/index.html
+++ b/static/index.html
@@ -1176,11 +1176,23 @@
     <div class="modal-body">
       <div id="discogs-section">
         <div class="form-group form-full" style="margin-bottom:1rem">
-          <label class="form-label">Discogs Release ID</label>
-          <input class="form-control" type="text" id="f-discogs-id" placeholder="e.g. r36875179 or 36875179">
-          <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
-            <button class="btn btn-secondary btn-sm" onclick="fetchDiscogs()" id="fetch-btn">Fetch</button>
-            <button class="btn btn-secondary btn-sm hidden" onclick="syncRecordFields(editingId)" id="sync-fields-btn">Sync Custom Fields</button>
+          <div style="display:flex;flex-wrap:wrap;gap:1rem;align-items:flex-start">
+            <div id="discogs-id-col" style="flex:1;min-width:200px">
+              <label class="form-label">Discogs Release ID</label>
+              <input class="form-control" type="text" id="f-discogs-id" placeholder="e.g. r36875179 or 36875179">
+              <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+                <button class="btn btn-secondary btn-sm" onclick="fetchDiscogs()" id="fetch-btn">Fetch</button>
+                <button class="btn btn-secondary btn-sm hidden" onclick="syncRecordFields(editingId)" id="sync-fields-btn">Sync Custom Fields</button>
+              </div>
+            </div>
+            <div id="discogs-or-divider" style="align-self:center;color:var(--ink-light);font-size:12px;white-space:nowrap;padding-top:1.5rem">— or —</div>
+            <div id="barcode-col" style="flex:1;min-width:200px">
+              <label class="form-label">Barcode</label>
+              <input class="form-control" type="text" id="f-barcode" placeholder="e.g. 602577603679" onkeydown="if(event.key==='Enter'){event.preventDefault();openBarcodeSearch(id=>{setField('f-discogs-id',id);fetchDiscogs();})}">
+              <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+                <button class="btn btn-secondary btn-sm" id="barcode-search-btn" onclick="openBarcodeSearch(id=>{setField('f-discogs-id',id);fetchDiscogs();})">Search</button>
+              </div>
+            </div>
           </div>
           <div id="discogs-preview" class="hidden" style="margin-top:0.5rem"></div>
         </div>
@@ -1307,6 +1319,26 @@
       <button class="btn btn-secondary" onclick="closeModal('modal-form')">Cancel</button>
       <button class="btn btn-danger btn-sm hidden" id="delete-btn" onclick="deleteRecord()">Delete</button>
       <button class="btn btn-primary" id="save-btn" onclick="saveRecord()">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Barcode Search Modal (stacked over #modal-form) ── -->
+<div class="modal-backdrop" id="modal-barcode-search">
+  <div class="modal" style="max-width:560px">
+    <div class="modal-header">
+      <span class="modal-title">Select a release</span>
+      <button class="btn btn-ghost btn-icon" onclick="closeModal('modal-barcode-search')">✕</button>
+    </div>
+    <div class="modal-body">
+      <div style="display:flex;gap:0.5rem;margin-bottom:1rem">
+        <input class="form-control" type="text" id="barcode-search-input" placeholder="Barcode digits…" onkeydown="if(event.key==='Enter')doBarcodeSearch()">
+        <button class="btn btn-primary btn-sm" onclick="doBarcodeSearch()" id="barcode-modal-search-btn">Search</button>
+      </div>
+      <div id="barcode-search-results"></div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closeModal('modal-barcode-search')">Close</button>
     </div>
   </div>
 </div>
@@ -1658,6 +1690,7 @@ let pendingQueue = [];
 let pendingUpdates = [];
 let _serverWishlistItems = [];
 let _lastSearchResults = [];
+let _barcodePickCb = null;
 
 // ── localStorage helpers ────────────────────────────────────────────────────
 function lsGet(key, fallback) {
@@ -2494,6 +2527,9 @@ function openAdd() {
   document.getElementById('fetch-btn').textContent = 'Fetch';
   document.getElementById('delete-btn').classList.add('hidden');
   document.getElementById('sync-fields-btn').classList.add('hidden');
+  document.getElementById('barcode-col').classList.remove('hidden');
+  document.getElementById('discogs-or-divider').classList.remove('hidden');
+  setField('f-barcode', '');
   resetForm();
   openModal('modal-form');
 }
@@ -2508,6 +2544,8 @@ function openEdit(id) {
   document.getElementById('discogs-section').style.display = '';
   document.getElementById('fetch-btn').textContent = 'Sync Metadata';
   document.getElementById('sync-fields-btn').classList.remove('hidden');
+  document.getElementById('barcode-col').classList.add('hidden');
+  document.getElementById('discogs-or-divider').classList.add('hidden');
   document.getElementById('discogs-preview').classList.add('hidden');
   document.getElementById('delete-btn').classList.remove('hidden');
 
@@ -3565,6 +3603,21 @@ function renderWishlist() {
     </div>`;
 }
 
+// Shared search-result row: thumb-or-placeholder + title + mono meta line + right action.
+// Reused by wishlist master search and barcode release search.
+function searchResultRow({ thumb, title, meta, actionHtml }) {
+  return `<div style="display:flex;align-items:center;gap:0.75rem;padding:0.6rem 0;border-bottom:1px solid var(--border)">
+    ${thumb
+      ? `<img src="${esc(thumb)}" style="width:48px;height:48px;object-fit:cover;border-radius:2px;flex-shrink:0">`
+      : `<div style="width:48px;height:48px;background:var(--surface);border-radius:2px;display:flex;align-items:center;justify-content:center;color:var(--groove);flex-shrink:0">♪</div>`}
+    <div style="flex:1;min-width:0">
+      <div style="font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${esc(title)}</div>
+      <div style="font-size:11px;color:var(--ink-light);font-family:var(--font-mono)">${esc(meta)}</div>
+    </div>
+    ${actionHtml}
+  </div>`;
+}
+
 function openWishlistSearchModal(prefill = '') {
   if (!navigator.onLine) { toast('No internet — wishlist search is unavailable offline', 'error'); return; }
   const input = document.getElementById('wishlist-search-input');
@@ -3613,21 +3666,65 @@ async function doWishlistSearch() {
     }
     results.innerHTML = items.map(item => {
       const existingItem = wishlistItems.find(w => String(w.master_id) === String(item.master_id));
-      return `<div style="display:flex;align-items:center;gap:0.75rem;padding:0.6rem 0;border-bottom:1px solid var(--border)">
-        ${item.thumb
-          ? `<img src="${esc(item.thumb)}" style="width:48px;height:48px;object-fit:cover;border-radius:2px;flex-shrink:0">`
-          : `<div style="width:48px;height:48px;background:var(--surface);border-radius:2px;display:flex;align-items:center;justify-content:center;color:var(--groove);flex-shrink:0">♪</div>`}
-        <div style="flex:1;min-width:0">
-          <div style="font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">${esc(item.title)}</div>
-          <div style="font-size:11px;color:var(--ink-light);font-family:var(--font-mono)">${item.year ? item.year + ' · ' : ''}master ${esc(item.master_id)}</div>
-        </div>
-        ${existingItem
-          ? `<span style="font-size:12px;color:var(--ink-light);white-space:nowrap;flex-shrink:0">${existingItem.fulfilled ? 'Fulfilled' : existingItem.pending ? 'Queued' : 'On wishlist'}</span>`
-          : `<button class="btn btn-primary btn-sm" style="flex-shrink:0" onclick="addToWishlist('${esc(item.master_id)}')">Add</button>`}
-      </div>`;
+      const meta = `${item.year ? item.year + ' · ' : ''}master ${item.master_id}`;
+      const actionHtml = existingItem
+        ? `<span style="font-size:12px;color:var(--ink-light);white-space:nowrap;flex-shrink:0">${existingItem.fulfilled ? 'Fulfilled' : existingItem.pending ? 'Queued' : 'On wishlist'}</span>`
+        : `<button class="btn btn-primary btn-sm" style="flex-shrink:0" onclick="addToWishlist('${esc(item.master_id)}')">Add</button>`;
+      return searchResultRow({ thumb: item.thumb, title: item.title, meta, actionHtml });
     }).join('');
   } catch {
     results.innerHTML = `<div style="color:var(--red);font-size:13px;padding:0.5rem 0">${serverReachable ? 'Search failed — check your Discogs token in Settings.' : 'Search failed — Discogs may be unreachable.'}</div>`;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Search';
+  }
+}
+
+// Generic, callback-driven release picker. onPick(releaseId) fires on Select.
+// The scanner FR reuses this unchanged.
+function openBarcodeSearch(onPick) {
+  _barcodePickCb = onPick;
+  const input = document.getElementById('barcode-search-input');
+  const pre = (document.getElementById('f-barcode')?.value || '').trim();
+  input.value = pre;
+  document.getElementById('barcode-search-results').innerHTML = '';
+  openModal('modal-barcode-search');
+  input.focus();
+  if (pre) doBarcodeSearch();
+}
+
+function barcodePick(id) {
+  if (_barcodePickCb) _barcodePickCb(id);
+  closeModal('modal-barcode-search');
+}
+
+async function doBarcodeSearch() {
+  const q = document.getElementById('barcode-search-input').value.trim();
+  if (!q) return;
+  const btn = document.getElementById('barcode-modal-search-btn');
+  const results = document.getElementById('barcode-search-results');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span>';
+  results.innerHTML = '<div style="color:var(--ink-light);font-size:13px;padding:0.5rem 0">Searching…</div>';
+  try {
+    const r = await apiFetch(`/api/discogs/search?barcode=${encodeURIComponent(q)}`);
+    if (!r.ok) throw new Error();
+    const items = await r.json();
+    items.sort((a, b) => (parseInt(b.year) || 0) - (parseInt(a.year) || 0));
+    if (!items.length) {
+      results.innerHTML = '<div style="color:var(--ink-light);font-size:13px;padding:0.5rem 0">No releases match that barcode.</div>';
+      return;
+    }
+    results.innerHTML = items.map(item => {
+      const meta = [item.year, item.country, item.catno, item.format].filter(Boolean).join(' · ');
+      const inColl = records.some(rec => String(rec.discogs_id || '').replace(/^r/, '') === String(item.id));
+      const actionHtml = inColl
+        ? `<span style="font-size:12px;color:var(--ink-light);white-space:nowrap;flex-shrink:0">In collection</span>`
+        : `<button class="btn btn-primary btn-sm" style="flex-shrink:0" onclick="barcodePick('${esc(item.id)}')">Select</button>`;
+      return searchResultRow({ thumb: item.thumb, title: item.title, meta, actionHtml });
+    }).join('');
+  } catch {
+    results.innerHTML = `<div style="color:var(--red);font-size:13px;padding:0.5rem 0">Search failed — check your Discogs token in Settings.</div>`;
   } finally {
     btn.disabled = false;
     btn.textContent = 'Search';

--- a/tests/TEST_INDEX.md
+++ b/tests/TEST_INDEX.md
@@ -79,6 +79,21 @@ Fast, isolated tests that run against the FastAPI app directly with a fresh SQLi
 
 ---
 
+### Discogs Search — `layer1/test_discogs_search.py`
+
+*`GET /api/discogs/search` — Discogs `/database/search` is mocked.*
+
+| Test | Purpose | Expected outcome |
+|------|---------|-----------------|
+| `test_search_by_barcode` | A barcode query returns shaped release results | `?barcode=` → one row with `id`/`title`/`year`/`country`/`label`/`catno`/`format`/`thumb` in the documented shape |
+| `test_search_by_q` | A free-text query hits the same endpoint | `?q=` → shaped results |
+| `test_search_missing_params_returns_400` | Neither `barcode` nor `q` supplied is rejected | `GET /api/discogs/search` with no params returns 400 |
+| `test_search_propagates_discogs_error_status` | A Discogs error status is forwarded to the caller | Mocked 502 from Discogs → endpoint returns 502 |
+| `test_search_empty_results` | No matches returns an empty list, not an error | Mocked empty `results` → 200 with `[]` |
+| `test_search_result_missing_optional_fields` | Results missing `label`/`format`/`thumb`/`year` don't crash the transform | Absent fields default to `""` / `None` |
+
+---
+
 ### Wishlist — `layer1/test_wishlist.py`
 
 *Discogs master fetch is mocked — no real API calls made.*

--- a/tests/layer1/test_discogs_search.py
+++ b/tests/layer1/test_discogs_search.py
@@ -1,0 +1,94 @@
+import pytest
+
+
+SAMPLE_SEARCH_RESPONSE = {
+    "results": [
+        {
+            "id": 12345678,
+            "title": "Test Artist - Test Album",
+            "year": "2019",
+            "country": "UK",
+            "label": ["Some Label", "Some Label"],
+            "catno": "ABC123",
+            "format": ["Vinyl", "LP", "Album"],
+            "thumb": "https://img.discogs.com/thumb.jpg",
+        }
+    ]
+}
+
+
+async def test_search_by_barcode(client, mock_discogs):
+    mock_get, _ = mock_discogs
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = SAMPLE_SEARCH_RESPONSE
+
+    r = await client.get("/api/discogs/search?barcode=602577603679")
+    assert r.status_code == 200
+    results = r.json()
+    assert len(results) == 1
+    assert results[0] == {
+        "id": "12345678",
+        "title": "Test Artist - Test Album",
+        "year": "2019",
+        "country": "UK",
+        "label": "Some Label",
+        "catno": "ABC123",
+        "format": "Vinyl, LP, Album",
+        "thumb": "https://img.discogs.com/thumb.jpg",
+    }
+
+
+async def test_search_by_q(client, mock_discogs):
+    mock_get, _ = mock_discogs
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = SAMPLE_SEARCH_RESPONSE
+
+    r = await client.get("/api/discogs/search?q=test+album")
+    assert r.status_code == 200
+    assert r.json()[0]["id"] == "12345678"
+
+
+async def test_search_missing_params_returns_400(client, mock_discogs):
+    r = await client.get("/api/discogs/search")
+    assert r.status_code == 400
+
+
+async def test_search_propagates_discogs_error_status(client, mock_discogs):
+    mock_get, _ = mock_discogs
+    mock_get.return_value.status_code = 502
+    mock_get.return_value.json.return_value = {}
+
+    r = await client.get("/api/discogs/search?barcode=602577603679")
+    assert r.status_code == 502
+
+
+async def test_search_empty_results(client, mock_discogs):
+    mock_get, _ = mock_discogs
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {"results": []}
+
+    r = await client.get("/api/discogs/search?barcode=000000000000")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+async def test_search_result_missing_optional_fields(client, mock_discogs):
+    mock_get, _ = mock_discogs
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "results": [{"id": 999, "title": "Bare Result"}]
+    }
+
+    r = await client.get("/api/discogs/search?q=bare")
+    assert r.status_code == 200
+    row = r.json()[0]
+    assert row == {
+        "id": "999",
+        "title": "Bare Result",
+        "year": None,
+        "country": "",
+        "label": "",
+        "catno": "",
+        "format": "",
+        "thumb": "",
+    }


### PR DESCRIPTION
## Partial resolution of #91

FR #91 is "add a record by its barcode". It ships as two PRs rolling into one release note:

- **This PR — barcode search.** Type the digits, pick a pressing.
- **Follow-up PR — camera scanner.** Header 📷 → camera → decode → opens the *same* picker. Branches off `main` after this merges.

**#91 stays open** until the scanner PR lands, then both close on the release that carries them. This is deliberately *not* `Closes #91`.

## What's in this PR

**Backend**
- `GET /api/discogs/search` — `?barcode=` and/or `?q=` (free-text), `type=release`, `per_page=25`, 400 if neither given. Mirrors `search_masters` (rate-limited `discogs_get`, status passthrough). `q` is wired now so the endpoint isn't barcode-locked for the scanner FR and later reuse.

**Frontend**
- Add Record form: `#discogs-section` is now a two-column row — `Release ID + Fetch` | `— or —` | `Barcode + Search`. Wraps on narrow widths.
- `#modal-barcode-search` — generic callback-driven release picker (`openBarcodeSearch(onPick)`), stacked over the form. Rows sorted year-desc, "In collection" label when the `discogs_id` already exists. Select populates the Release ID field and fires the normal `fetchDiscogs()` — nothing downstream changes.
- Barcode search is **Add-only**; `openEdit()` hides the column + divider.
- `searchResultRow()` helper extracted; `doWishlistSearch()` refactored onto it (no behaviour change).

**Other**
- 6 endpoint tests (`tests/layer1/test_discogs_search.py`); full layer1 suite green.
- `.gitignore` excludes local working specs (`docs/fr-*.md`).
- `CLAUDE.md` updated: endpoint, modal, global state, key functions.

## Testing

- `pytest tests/layer1` — 80 passed
- Manual: Add → barcode `602577603679` → 2 Florence pressings → Select → form fills via Fetch → saved. Edit shows no barcode field. ESC closes only the picker. Narrow-width layout OK. Wishlist search unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)